### PR TITLE
UF-4388: Add municipality utilities.

### DIFF
--- a/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/ValidBase64.java
+++ b/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/ValidBase64.java
@@ -13,7 +13,7 @@ import se.sundsvall.dept44.common.validators.annotation.impl.ValidBase64Constrai
 
 /**
  * The annotated element must be properly BASE64-encoded according to RFC 4648. Accepts CharSequence.
- * 
+ *
  * @see <a href="https://www.rfc-editor.org/rfc/rfc4648">RFC 4648</a>
  */
 @Documented
@@ -22,19 +22,34 @@ import se.sundsvall.dept44.common.validators.annotation.impl.ValidBase64Constrai
 @Constraint(validatedBy = ValidBase64ConstraintValidator.class)
 public @interface ValidBase64 {
 
+	/**
+	 * Returns the message.
+	 *
+	 * @return the message.
+	 */
 	String message() default "not a valid BASE64-encoded string";
 
 	/**
 	 * Controls whether the value can be null or not.
-	 * 
+	 *
 	 * If set to true, the validator will accept the value as valid when null.
 	 * If set to false (default), the validator will reject the value as invalid when null.
-	 * 
+	 *
 	 * @return true if the value is accepted as nullable, false otherwise.
 	 */
 	boolean nullable() default false;
 
+	/**
+	 * Returns the groups.
+	 *
+	 * @return the groups.
+	 */
 	Class<?>[] groups() default {};
 
+	/**
+	 * Returns the payload.
+	 *
+	 * @return the payload.
+	 */
 	Class<? extends Payload>[] payload() default {};
 }

--- a/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/ValidMobileNumber.java
+++ b/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/ValidMobileNumber.java
@@ -12,9 +12,11 @@ import javax.validation.Payload;
 import se.sundsvall.dept44.common.validators.annotation.impl.ValidMobileNumberConstraintValidator;
 
 /**
- * The annotated element must be a valid mobile number according to the regular expression ^07[02369]\d{7}$. Accepts CharSequence.
- * 
- * @see <a href="https://sundsvall.atlassian.net/wiki/spaces/SK/pages/22675457/OpenAPI+namns+ttning">Open API namnsättning</a>
+ * The annotated element must be a valid mobile number according to the regular expression ^07[02369]\d{7}$. Accepts
+ * CharSequence.
+ *
+ * @see <a href="https://sundsvall.atlassian.net/wiki/spaces/SK/pages/22675457/OpenAPI+namns+ttning">Open API
+ *      namnsättning</a>
  */
 @Documented
 @Target({ ElementType.FIELD, ElementType.CONSTRUCTOR, ElementType.PARAMETER, ElementType.TYPE_USE })
@@ -22,19 +24,34 @@ import se.sundsvall.dept44.common.validators.annotation.impl.ValidMobileNumberCo
 @Constraint(validatedBy = ValidMobileNumberConstraintValidator.class)
 public @interface ValidMobileNumber {
 
+	/**
+	 * Returns the message.
+	 *
+	 * @return the message.
+	 */
 	String message() default "must match the regular expression ^07[02369]\\d{7}$";
 
 	/**
 	 * Controls whether the value can be null or not.
-	 * 
+	 *
 	 * If set to true, the validator will accept the value as valid when null.
 	 * If set to false (default), the validator will reject the value as invalid when null.
-	 * 
+	 *
 	 * @return true if the value is accepted as nullable, false otherwise.
 	 */
 	boolean nullable() default false;
 
+	/**
+	 * Returns the groups.
+	 *
+	 * @return the groups.
+	 */
 	Class<?>[] groups() default {};
 
+	/**
+	 * Returns the payload.
+	 *
+	 * @return the payload.
+	 */
 	Class<? extends Payload>[] payload() default {};
 }

--- a/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/ValidMunicipalityId.java
+++ b/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/ValidMunicipalityId.java
@@ -12,9 +12,11 @@ import javax.validation.Payload;
 import se.sundsvall.dept44.common.validators.annotation.impl.ValidMunicipalityIdConstraintValidator;
 
 /**
- * The annotated element must be a valid municipality id according to the regular expression ^d{4}$. Accepts CharSequence.
- * 
- * @see <a href="https://sundsvall.atlassian.net/wiki/spaces/SK/pages/22675457/OpenAPI+namns+ttning">Open API namnsättning</a>
+ * The annotated element must be a valid municipality id according to the regular expression ^d{4}$. Accepts
+ * CharSequence.
+ *
+ * @see <a href="https://sundsvall.atlassian.net/wiki/spaces/SK/pages/22675457/OpenAPI+namns+ttning">Open API
+ *      namnsättning</a>
  */
 @Documented
 @Target({ ElementType.FIELD, ElementType.CONSTRUCTOR, ElementType.PARAMETER, ElementType.TYPE_USE })
@@ -22,19 +24,34 @@ import se.sundsvall.dept44.common.validators.annotation.impl.ValidMunicipalityId
 @Constraint(validatedBy = ValidMunicipalityIdConstraintValidator.class)
 public @interface ValidMunicipalityId {
 
-	String message() default "must match the regular expression ^\\d{4}$";
+	/**
+	 * Returns the message.
+	 *
+	 * @return the message.
+	 */
+	String message() default "not a valid municipality ID";
 
 	/**
 	 * Controls whether the value can be null or not.
-	 * 
+	 *
 	 * If set to true, the validator will accept the value as valid when null.
 	 * If set to false (default), the validator will reject the value as invalid when null.
-	 * 
+	 *
 	 * @return true if the value is accepted as nullable, false otherwise.
 	 */
 	boolean nullable() default false;
 
+	/**
+	 * Returns the groups.
+	 *
+	 * @return the groups.
+	 */
 	Class<?>[] groups() default {};
 
+	/**
+	 * Returns the payload.
+	 *
+	 * @return the payload.
+	 */
 	Class<? extends Payload>[] payload() default {};
 }

--- a/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/ValidOrganizationNumber.java
+++ b/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/ValidOrganizationNumber.java
@@ -12,9 +12,11 @@ import javax.validation.Payload;
 import se.sundsvall.dept44.common.validators.annotation.impl.ValidOrganizationNumberConstraintValidator;
 
 /**
- * The annotated element must be a valid organization number according to the regular expression ^([1235789][\d][2-9]\d{7})$. Accepts CharSequence.
- * 
- * @see <a href="https://sundsvall.atlassian.net/wiki/spaces/SK/pages/22675457/OpenAPI+namns+ttning">Open API namnsättning</a>
+ * The annotated element must be a valid organization number according to the regular expression
+ * ^([1235789][\d][2-9]\d{7})$. Accepts CharSequence.
+ *
+ * @see <a href="https://sundsvall.atlassian.net/wiki/spaces/SK/pages/22675457/OpenAPI+namns+ttning">Open API
+ *      namnsättning</a>
  */
 @Documented
 @Target({ ElementType.FIELD, ElementType.CONSTRUCTOR, ElementType.PARAMETER, ElementType.TYPE_USE })
@@ -22,19 +24,34 @@ import se.sundsvall.dept44.common.validators.annotation.impl.ValidOrganizationNu
 @Constraint(validatedBy = ValidOrganizationNumberConstraintValidator.class)
 public @interface ValidOrganizationNumber {
 
+	/**
+	 * Returns the message.
+	 *
+	 * @return the message.
+	 */
 	String message() default "must match the regular expression ^([1235789][\\d][2-9]\\d{7})$";
 
 	/**
 	 * Controls whether the value can be null or not.
-	 * 
+	 *
 	 * If set to true, the validator will accept the value as valid when null.
 	 * If set to false (default), the validator will reject the value as invalid when null.
-	 * 
+	 *
 	 * @return true if the value is accepted as nullable, false otherwise.
 	 */
 	boolean nullable() default false;
 
+	/**
+	 * Returns the groups.
+	 *
+	 * @return the groups.
+	 */
 	Class<?>[] groups() default {};
 
+	/**
+	 * Returns the payload.
+	 *
+	 * @return the payload.
+	 */
 	Class<? extends Payload>[] payload() default {};
 }

--- a/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/ValidPersonalNumber.java
+++ b/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/ValidPersonalNumber.java
@@ -12,9 +12,11 @@ import javax.validation.Payload;
 import se.sundsvall.dept44.common.validators.annotation.impl.ValidPersonalNumberConstraintValidator;
 
 /**
- * The annotated element must be a valid personal number according to the regular expression ^(19|20)[0-9]{10}$. Accepts CharSequence.
- * 
- * @see <a href="https://sundsvall.atlassian.net/wiki/spaces/SK/pages/22675457/OpenAPI+namns+ttning">Open API namnsättning</a>
+ * The annotated element must be a valid personal number according to the regular expression ^(19|20)[0-9]{10}$. Accepts
+ * CharSequence.
+ *
+ * @see <a href="https://sundsvall.atlassian.net/wiki/spaces/SK/pages/22675457/OpenAPI+namns+ttning">Open API
+ *      namnsättning</a>
  */
 @Documented
 @Target({ ElementType.FIELD, ElementType.CONSTRUCTOR, ElementType.PARAMETER, ElementType.TYPE_USE })
@@ -22,19 +24,34 @@ import se.sundsvall.dept44.common.validators.annotation.impl.ValidPersonalNumber
 @Constraint(validatedBy = ValidPersonalNumberConstraintValidator.class)
 public @interface ValidPersonalNumber {
 
+	/**
+	 * Returns the message.
+	 *
+	 * @return the message.
+	 */
 	String message() default "must match the regular expression ^(19|20)[0-9]{10}$";
 
 	/**
 	 * Controls whether the value can be null or not.
-	 * 
+	 *
 	 * If set to true, the validator will accept the value as valid when null.
 	 * If set to false (default), the validator will reject the value as invalid when null.
-	 * 
+	 *
 	 * @return true if the value is accepted as nullable, false otherwise.
 	 */
 	boolean nullable() default false;
 
+	/**
+	 * Returns the groups.
+	 *
+	 * @return the groups.
+	 */
 	Class<?>[] groups() default {};
 
+	/**
+	 * Returns the payload.
+	 *
+	 * @return the payload.
+	 */
 	Class<? extends Payload>[] payload() default {};
 }

--- a/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/ValidUuid.java
+++ b/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/ValidUuid.java
@@ -13,7 +13,7 @@ import se.sundsvall.dept44.common.validators.annotation.impl.ValidUuidConstraint
 
 /**
  * The annotated element must be a valid UUID according to RFC 4122. Accepts CharSequence.
- * 
+ *
  * @see <a href="http://www.ietf.org/rfc/rfc4122.txt">RFC 4122</a>
  */
 @Documented
@@ -22,19 +22,34 @@ import se.sundsvall.dept44.common.validators.annotation.impl.ValidUuidConstraint
 @Constraint(validatedBy = ValidUuidConstraintValidator.class)
 public @interface ValidUuid {
 
+	/**
+	 * Returns the message.
+	 *
+	 * @return the message.
+	 */
 	String message() default "not a valid UUID";
 
 	/**
 	 * Controls whether the value can be null or not.
-	 * 
+	 *
 	 * If set to true, the validator will accept the value as valid when null.
 	 * If set to false (default), the validator will reject the value as invalid when null.
-	 * 
+	 *
 	 * @return true if the value is accepted as nullable, false otherwise.
 	 */
 	boolean nullable() default false;
 
+	/**
+	 * Returns the groups.
+	 *
+	 * @return the groups.
+	 */
 	Class<?>[] groups() default {};
 
+	/**
+	 * Returns the payload.
+	 *
+	 * @return the payload.
+	 */
 	Class<? extends Payload>[] payload() default {};
 }

--- a/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/exception/IncompatibleAnnotationException.java
+++ b/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/exception/IncompatibleAnnotationException.java
@@ -1,9 +1,17 @@
 package se.sundsvall.dept44.common.validators.annotation.exception;
 
+/**
+ * Exception that will be thrown if the used annotation does not contain required methods.
+ */
 public class IncompatibleAnnotationException extends RuntimeException {
 	private static final long serialVersionUID = 5071957184294984636L;
-	
-	public IncompatibleAnnotationException(String message) {
+
+	/**
+	 * Creates a new IncompatibleAnnotationException.
+	 *
+	 * @param message the exception message.
+	 */
+	public IncompatibleAnnotationException(final String message) {
 		super(message);
 	}
 }

--- a/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/impl/AbstractValidator.java
+++ b/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/impl/AbstractValidator.java
@@ -14,11 +14,21 @@ abstract class AbstractValidator {
 
 	static final String MESSAGE_METHOD_NAME = "message";
 
+	/**
+	 * Returns the message.
+	 *
+	 * @return the message.
+	 */
 	abstract String getMessage();
-	
+
+	/**
+	 * Returns if the validation evaluates to 'valid' or not.
+	 *
+	 * @return true if valid, false otherwise.
+	 */
 	abstract boolean isValid(final String value);
-	
-	static final Supplier<IncompatibleAnnotationException> createException(@NotNull String className) {
+
+	static final Supplier<IncompatibleAnnotationException> createException(@NotNull final String className) {
 		return () -> new IncompatibleAnnotationException(String.format("%s does not contain method %s()",
 			requireNonNull(className, "className may not be null"), MESSAGE_METHOD_NAME));
 	}

--- a/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidBase64ConstraintValidator.java
+++ b/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidBase64ConstraintValidator.java
@@ -12,6 +12,9 @@ import javax.validation.ConstraintValidatorContext;
 
 import se.sundsvall.dept44.common.validators.annotation.ValidBase64;
 
+/**
+ * Defines the logic to validate that a string is a valid base64-string.
+ */
 public class ValidBase64ConstraintValidator extends AbstractValidator implements ConstraintValidator<ValidBase64, String> {
 
 	private static final Base64.Decoder BASE64_DECODER = Base64.getDecoder();
@@ -47,7 +50,7 @@ public class ValidBase64ConstraintValidator extends AbstractValidator implements
 	private boolean isValidBase64(final String value) {
 		try {
 			BASE64_DECODER.decode(value);
-		} catch (Exception e) {
+		} catch (final Exception e) {
 			return false;
 		}
 

--- a/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidMobileNumberConstraintValidator.java
+++ b/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidMobileNumberConstraintValidator.java
@@ -12,13 +12,16 @@ import javax.validation.ConstraintValidatorContext;
 
 import se.sundsvall.dept44.common.validators.annotation.ValidMobileNumber;
 
+/**
+ * Defines the logic to validate that a string is a valid mobile number.
+ */
 public class ValidMobileNumberConstraintValidator extends AbstractValidator implements ConstraintValidator<ValidMobileNumber, String> {
 
 	private static final String REGEX_PATTERN = "^07[02369]\\d{7}$";
 	private boolean nullable;
 
 	@Override
-	public void initialize(ValidMobileNumber constraintAnnotation) {
+	public void initialize(final ValidMobileNumber constraintAnnotation) {
 		this.nullable = constraintAnnotation.nullable();
 	}
 

--- a/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidMunicipalityIdConstraintValidator.java
+++ b/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidMunicipalityIdConstraintValidator.java
@@ -11,14 +11,17 @@ import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 
 import se.sundsvall.dept44.common.validators.annotation.ValidMunicipalityId;
+import se.sundsvall.dept44.util.MunicipalityUtils;
 
+/**
+ * Defines the logic to validate that a string is a valid municipality ID.
+ */
 public class ValidMunicipalityIdConstraintValidator extends AbstractValidator implements ConstraintValidator<ValidMunicipalityId, String> {
 
-	private static final String REGEX = "^\\d{4}$";
 	private boolean nullable;
 
 	@Override
-	public void initialize(ValidMunicipalityId constraintAnnotation) {
+	public void initialize(final ValidMunicipalityId constraintAnnotation) {
 		this.nullable = constraintAnnotation.nullable();
 	}
 
@@ -28,7 +31,7 @@ public class ValidMunicipalityIdConstraintValidator extends AbstractValidator im
 			return true;
 		}
 
-		return nonNull(value) && value.matches(REGEX);
+		return nonNull(value) && MunicipalityUtils.existsById(value);
 	}
 
 	@Override

--- a/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidOrganizationNumberConstraintValidator.java
+++ b/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidOrganizationNumberConstraintValidator.java
@@ -12,13 +12,16 @@ import javax.validation.ConstraintValidatorContext;
 
 import se.sundsvall.dept44.common.validators.annotation.ValidOrganizationNumber;
 
+/**
+ * Defines the logic to validate that a string is a valid organization number.
+ */
 public class ValidOrganizationNumberConstraintValidator extends AbstractValidator implements ConstraintValidator<ValidOrganizationNumber, String> {
 
 	private static final String REGEX_PATTERN = "^([1235789][\\d][2-9]\\d{7})$";
 	private boolean nullable;
 
 	@Override
-	public void initialize(ValidOrganizationNumber constraintAnnotation) {
+	public void initialize(final ValidOrganizationNumber constraintAnnotation) {
 		this.nullable = constraintAnnotation.nullable();
 	}
 

--- a/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidPersonalNumberConstraintValidator.java
+++ b/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidPersonalNumberConstraintValidator.java
@@ -12,13 +12,16 @@ import javax.validation.ConstraintValidatorContext;
 
 import se.sundsvall.dept44.common.validators.annotation.ValidPersonalNumber;
 
+/**
+ * Defines the logic to validate that a string is a valid personal number.
+ */
 public class ValidPersonalNumberConstraintValidator extends AbstractValidator implements ConstraintValidator<ValidPersonalNumber, String> {
 
 	private static final String REGEX_PATTERN = "^(19|20)\\d{10}$";
 	private boolean nullable;
 
 	@Override
-	public void initialize(ValidPersonalNumber constraintAnnotation) {
+	public void initialize(final ValidPersonalNumber constraintAnnotation) {
 		this.nullable = constraintAnnotation.nullable();
 	}
 

--- a/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidUuidConstraintValidator.java
+++ b/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidUuidConstraintValidator.java
@@ -12,12 +12,15 @@ import javax.validation.ConstraintValidatorContext;
 
 import se.sundsvall.dept44.common.validators.annotation.ValidUuid;
 
+/**
+ * Defines the logic to validate that a string is a valid UUID.
+ */
 public class ValidUuidConstraintValidator extends AbstractValidator implements ConstraintValidator<ValidUuid, String> {
 
 	private boolean nullable;
 
 	@Override
-	public void initialize(ValidUuid constraintAnnotation) {
+	public void initialize(final ValidUuid constraintAnnotation) {
 		this.nullable = constraintAnnotation.nullable();
 	}
 
@@ -42,10 +45,10 @@ public class ValidUuidConstraintValidator extends AbstractValidator implements C
 			.orElseThrow(createException(ValidUuid.class.getName()));
 	}
 
-	private boolean isValidUUID(String value) {
+	private boolean isValidUUID(final String value) {
 		try {
 			UUID.fromString(String.valueOf(value));
-		} catch (Exception e) {
+		} catch (final Exception e) {
 			return false;
 		}
 

--- a/dept44-common-validators/src/test/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidMunicipalityIdConstraintValidatorTest.java
+++ b/dept44-common-validators/src/test/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidMunicipalityIdConstraintValidatorTest.java
@@ -28,8 +28,8 @@ class ValidMunicipalityIdConstraintValidatorTest {
 		// Mock
 		validator.initialize(annotationMock);
 
-		assertThat(validator.isValid("1234")).isTrue();
-		assertThat(validator.isValid("1234", null)).isTrue();
+		assertThat(validator.isValid("2281")).isTrue();
+		assertThat(validator.isValid("2281", null)).isTrue();
 
 		verify(annotationMock).nullable();
 	}
@@ -74,7 +74,7 @@ class ValidMunicipalityIdConstraintValidatorTest {
 
 	@Test
 	void testMessage() {
-		assertThat(validator.getMessage()).isEqualTo("must match the regular expression ^\\d{4}$");
+		assertThat(validator.getMessage()).isEqualTo("not a valid municipality ID");
 
 		verifyNoInteractions(annotationMock);
 	}

--- a/dept44-starter-feign/src/main/java/se/sundsvall/dept44/configuration/feign/decoder/AbstractErrorDecoder.java
+++ b/dept44-starter-feign/src/main/java/se/sundsvall/dept44/configuration/feign/decoder/AbstractErrorDecoder.java
@@ -30,6 +30,9 @@ import feign.codec.ErrorDecoder;
 import se.sundsvall.dept44.exception.ClientProblem;
 import se.sundsvall.dept44.exception.ServerProblem;
 
+/**
+ * The base error decoder.
+ */
 public abstract class AbstractErrorDecoder implements ErrorDecoder {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(AbstractErrorDecoder.class);
@@ -128,6 +131,7 @@ public abstract class AbstractErrorDecoder implements ErrorDecoder {
 	 *
 	 * @param response the response that caused the error.
 	 * @return a String that represents the error message returned in the response.
+	 * @throws Exception if something goes wrong.
 	 */
 	public abstract String extractErrorMessage(Response response) throws Exception;
 

--- a/dept44-starter/src/main/java/se/sundsvall/dept44/util/DateUtils.java
+++ b/dept44-starter/src/main/java/se/sundsvall/dept44/util/DateUtils.java
@@ -8,47 +8,47 @@ import java.time.ZoneId;
 import java.time.temporal.Temporal;
 import java.util.Optional;
 
-public class DateUtils {
+public final class DateUtils {
 
 	private DateUtils() {}
 
 	/**
 	 * This method converts the provided OffsetDateTime or LocalDateTime object into a new OffsetDateTime with the local
 	 * offset.
-	 * 
+	 *
 	 * Please note that it only has support for OffsetDateTime and LocalDateTime and no other Temporal-types.
-	 * 
+	 *
 	 * E.g. if local timezone is "Europe/Stockholm", this would be the result for the provided dates:
-	 * 
+	 *
 	 * <pre>
 	 * Zulu time zone into time with local offset +1h.
 	 * 2021-11-10T09:23:42.500Z -> 2021-11-10T10:23:42.500+01:00
-	 * 
+	 *
 	 * Zulu time zone into time with local offset +2h, with DST.
 	 * 2021-06-10T09:23:42.500Z -> 2021-06-10T11:23:42.500+02:00
-	 * 
-	 * Time with offset +4h into time with local offset +1h. 
+	 *
+	 * Time with offset +4h into time with local offset +1h.
 	 * 2021-11-10T12:23:42.500+04:00 -> 2021-11-10T09:23:42.500+01:00
-	 * 
+	 *
 	 * Time with no offset (e.g. LocalDateTime), with DST.
 	 * 2021-06-10T09:23:42 -> 2021-06-10T11:23:42+02:00
-	 * 
+	 *
 	 * Time with no offset (e.g. LocalDateTime).
 	 * 2021-11-10T09:23:42 -> 2021-11-10T11:23:42+01:00
 	 * </pre>
-	 * 
+	 *
 	 * @param temporal
 	 * @return a new offsetDateTime with the local offset. If the temporal is null, null is returned.
 	 * @throws IllegalArgumentException if a temporal type is not OffsetDateTime or LocalDateTime.
 	 */
-	public static OffsetDateTime toOffsetDateTimeWithLocalOffset(Temporal temporal) {
+	public static OffsetDateTime toOffsetDateTimeWithLocalOffset(final Temporal temporal) {
 		if (isNull(temporal)) {
 			return null;
 		}
-		if (temporal instanceof OffsetDateTime offsetDateTime) {
+		if (temporal instanceof final OffsetDateTime offsetDateTime) {
 			return toOffsetDateTimeWithLocalOffset(offsetDateTime);
 		}
-		if (temporal instanceof LocalDateTime localDateTime) {
+		if (temporal instanceof final LocalDateTime localDateTime) {
 			return toOffsetDateTimeWithLocalOffset(localDateTime);
 		}
 		throw new IllegalArgumentException("Method has no support for type " + temporal.getClass().getName());
@@ -60,7 +60,7 @@ public class DateUtils {
 	 * @param offsetDateTime
 	 * @return offsetDateTime with local offset
 	 */
-	private static OffsetDateTime toOffsetDateTimeWithLocalOffset(OffsetDateTime offsetDateTime) {
+	private static OffsetDateTime toOffsetDateTimeWithLocalOffset(final OffsetDateTime offsetDateTime) {
 		return Optional.ofNullable(offsetDateTime)
 			// Calculate local offset based on provided offsetDateTime, for this systems zoneId.
 			.map(offsetDateTime1 -> offsetDateTime1.withOffsetSameInstant(ZoneId.systemDefault().getRules().getOffset(offsetDateTime1.toInstant())))
@@ -73,7 +73,7 @@ public class DateUtils {
 	 * @param localDateTime
 	 * @return offsetDateTime with local offset
 	 */
-	private static OffsetDateTime toOffsetDateTimeWithLocalOffset(LocalDateTime localDateTime) {
+	private static OffsetDateTime toOffsetDateTimeWithLocalOffset(final LocalDateTime localDateTime) {
 		return Optional.ofNullable(localDateTime)
 			.map(localDateTime1 -> localDateTime1.atOffset(ZoneId.systemDefault().getRules().getOffset(localDateTime1)))
 			.orElse(null);

--- a/dept44-starter/src/main/java/se/sundsvall/dept44/util/EncodingUtils.java
+++ b/dept44-starter/src/main/java/se/sundsvall/dept44/util/EncodingUtils.java
@@ -3,20 +3,20 @@ package se.sundsvall.dept44.util;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-public class EncodingUtils {
+public final class EncodingUtils {
 
 	private EncodingUtils() {}
 
 	/**
 	 * Removes double encoded content.
-	 * 
+	 *
 	 * If a String contains characters like: "ÃÃÃÃ¥Ã¤Ã¶", it might be double encoded.
 	 * By running it through this method, it will become correctly UTF-8 encoded again.
-	 * 
+	 *
 	 * @param string
 	 * @return the corrected string
 	 */
-	public static String fixDoubleEncodedUTF8Content(String string) {
+	public static String fixDoubleEncodedUTF8Content(final String string) {
 		if (isDoubleEncodedUTF8Content(string)) {
 			// Fix the string by assuming it is ASCII extended and recode it once.
 			return new String(string.getBytes(ISO_8859_1), UTF_8);
@@ -26,19 +26,19 @@ public class EncodingUtils {
 
 	/**
 	 * Check if a string contains double encoded UTF-8 content.
-	 * 
+	 *
 	 * If a String contains characters like: "ÃÃÃÃ¥Ã¤Ã¶", it might be double encoded.
 	 * This method will detect that.
-	 * 
+	 *
 	 * @param string content to check
 	 * @return true if the string content is double encoded, false otherwise.
 	 */
-	public static boolean isDoubleEncodedUTF8Content(String string) {
+	public static boolean isDoubleEncodedUTF8Content(final String string) {
 		// Interpret the string as UTF-8
 		final var bytes = string.getBytes(UTF_8);
 
 		// Now check if the bytes contain 0x83 0xC2, meaning double encoded garbage.
-		for (int i = 0; i < bytes.length; i++) {
+		for (var i = 0; i < bytes.length; i++) {
 			if (bytes[i] == -125 && i + 1 < bytes.length && bytes[i + 1] == -62) {
 				return true;
 			}

--- a/dept44-starter/src/main/java/se/sundsvall/dept44/util/MunicipalityUtils.java
+++ b/dept44-starter/src/main/java/se/sundsvall/dept44/util/MunicipalityUtils.java
@@ -14,7 +14,7 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-public class MunicipalityUtils {
+public final class MunicipalityUtils {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(MunicipalityUtils.class);
 	private static final String MUNICIPALITY_DEFINITION_PATH = "classpath:data/municipality.json";

--- a/dept44-starter/src/main/java/se/sundsvall/dept44/util/MunicipalityUtils.java
+++ b/dept44-starter/src/main/java/se/sundsvall/dept44/util/MunicipalityUtils.java
@@ -1,0 +1,90 @@
+package se.sundsvall.dept44.util;
+
+import static java.util.Comparator.comparing;
+import static org.apache.commons.lang3.StringUtils.upperCase;
+import static org.springframework.util.ResourceUtils.getURL;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class MunicipalityUtils {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(MunicipalityUtils.class);
+	private static final String MUNICIPALITY_DEFINITION_PATH = "classpath:data/municipality.json";
+	private static final Map<String, Municipality> MUNICIPALITY_BY_ID_MAP = new HashMap<>();
+	private static final Map<String, Municipality> MUNICIPALITY_BY_NAME_MAP = new HashMap<>();
+
+	static {
+		try {
+			new ObjectMapper().readValue(getURL(MUNICIPALITY_DEFINITION_PATH), new TypeReference<List<Municipality>>() {}).stream()
+				.forEach(municipality -> {
+					MUNICIPALITY_BY_ID_MAP.put(municipality.id(), municipality);
+					MUNICIPALITY_BY_NAME_MAP.put(upperCase(municipality.name()), municipality);
+				});
+		} catch (final Exception e) {
+			LOGGER.error("Error during class initialization", e);
+		}
+	}
+
+	private MunicipalityUtils() {}
+
+	/**
+	 * Find municipality by ID.
+	 *
+	 * @param id the municipality ID.
+	 * @return The municipality object if found, otherwise null.
+	 */
+	public static Municipality findById(final String id) {
+		return MUNICIPALITY_BY_ID_MAP.get(id);
+	}
+
+	/**
+	 * Find municipality by name.
+	 *
+	 * @param name the municipality name (case insensitive).
+	 * @return The municipality object if found, otherwise null.
+	 */
+	public static Municipality findByName(final String name) {
+		return MUNICIPALITY_BY_NAME_MAP.get(upperCase(name));
+	}
+
+	/**
+	 * Returns true if a municipality exists by the provided key.
+	 *
+	 * @param id the municipality ID.
+	 * @return true if the municipality exists, otherwise false.
+	 */
+	public static boolean existsById(final String id) {
+		return MUNICIPALITY_BY_ID_MAP.containsKey(id);
+	}
+
+	/**
+	 * Returns true if a municipality exists by the provided name (case insensitive).
+	 *
+	 * @param name the municipality name.
+	 * @return true if the municipality exists, otherwise false.
+	 */
+	public static boolean existsByName(final String name) {
+		return MUNICIPALITY_BY_NAME_MAP.containsKey(upperCase(name));
+	}
+
+	/**
+	 * Returns the total list of municipality id/name mappings.
+	 *
+	 * @return all municipalities.
+	 */
+	public static List<Municipality> findAll() {
+		return MUNICIPALITY_BY_ID_MAP.values().stream()
+			.sorted(comparing(Municipality::id))
+			.toList();
+	}
+
+	public static record Municipality(String id, String name) {}
+}

--- a/dept44-starter/src/main/resources/data/municipality.json
+++ b/dept44-starter/src/main/resources/data/municipality.json
@@ -1,0 +1,1246 @@
+[
+    {
+        "id": "01",
+        "name": "Stockholms län"
+    },
+    {
+        "id": "0114",
+        "name": "Upplands Väsby"
+    },
+    {
+        "id": "0115",
+        "name": "Vallentuna"
+    },
+    {
+        "id": "0117",
+        "name": "Österåker"
+    },
+    {
+        "id": "0120",
+        "name": "Värmdö"
+    },
+    {
+        "id": "0123",
+        "name": "Järfälla"
+    },
+    {
+        "id": "0125",
+        "name": "Ekerö"
+    },
+    {
+        "id": "0126",
+        "name": "Huddinge"
+    },
+    {
+        "id": "0127",
+        "name": "Botkyrka"
+    },
+    {
+        "id": "0128",
+        "name": "Salem"
+    },
+    {
+        "id": "0136",
+        "name": "Haninge"
+    },
+    {
+        "id": "0138",
+        "name": "Tyresö"
+    },
+    {
+        "id": "0139",
+        "name": "Upplands-Bro"
+    },
+    {
+        "id": "0140",
+        "name": "Nykvarn"
+    },
+    {
+        "id": "0160",
+        "name": "Täby"
+    },
+    {
+        "id": "0162",
+        "name": "Danderyd"
+    },
+    {
+        "id": "0163",
+        "name": "Sollentuna"
+    },
+    {
+        "id": "0180",
+        "name": "Stockholm"
+    },
+    {
+        "id": "0181",
+        "name": "Södertälje"
+    },
+    {
+        "id": "0182",
+        "name": "Nacka"
+    },
+    {
+        "id": "0183",
+        "name": "Sundbyberg"
+    },
+    {
+        "id": "0184",
+        "name": "Solna"
+    },
+    {
+        "id": "0186",
+        "name": "Lidingö"
+    },
+    {
+        "id": "0187",
+        "name": "Vaxholm"
+    },
+    {
+        "id": "0188",
+        "name": "Norrtälje"
+    },
+    {
+        "id": "0191",
+        "name": "Sigtuna"
+    },
+    {
+        "id": "0192",
+        "name": "Nynäshamn"
+    },
+    {
+        "id": "03",
+        "name": "Uppsala län"
+    },
+    {
+        "id": "0305",
+        "name": "Håbo"
+    },
+    {
+        "id": "0319",
+        "name": "Älvkarleby"
+    },
+    {
+        "id": "0330",
+        "name": "Knivsta"
+    },
+    {
+        "id": "0331",
+        "name": "Heby"
+    },
+    {
+        "id": "0360",
+        "name": "Tierp"
+    },
+    {
+        "id": "0380",
+        "name": "Uppsala"
+    },
+    {
+        "id": "0381",
+        "name": "Enköping"
+    },
+    {
+        "id": "0382",
+        "name": "Östhammar"
+    },
+    {
+        "id": "04",
+        "name": "Södermanlands län"
+    },
+    {
+        "id": "0428",
+        "name": "Vingåker"
+    },
+    {
+        "id": "0461",
+        "name": "Gnesta"
+    },
+    {
+        "id": "0480",
+        "name": "Nyköping"
+    },
+    {
+        "id": "0481",
+        "name": "Oxelösund"
+    },
+    {
+        "id": "0482",
+        "name": "Flen"
+    },
+    {
+        "id": "0483",
+        "name": "Katrineholm"
+    },
+    {
+        "id": "0484",
+        "name": "Eskilstuna"
+    },
+    {
+        "id": "0486",
+        "name": "Strängnäs"
+    },
+    {
+        "id": "0488",
+        "name": "Trosa"
+    },
+    {
+        "id": "05",
+        "name": "Östergötlands län"
+    },
+    {
+        "id": "0509",
+        "name": "Ödeshög"
+    },
+    {
+        "id": "0512",
+        "name": "Ydre"
+    },
+    {
+        "id": "0513",
+        "name": "Kinda"
+    },
+    {
+        "id": "0560",
+        "name": "Boxholm"
+    },
+    {
+        "id": "0561",
+        "name": "Åtvidaberg"
+    },
+    {
+        "id": "0562",
+        "name": "Finspång"
+    },
+    {
+        "id": "0563",
+        "name": "Valdemarsvik"
+    },
+    {
+        "id": "0580",
+        "name": "Linköping"
+    },
+    {
+        "id": "0581",
+        "name": "Norrköping"
+    },
+    {
+        "id": "0582",
+        "name": "Söderköping"
+    },
+    {
+        "id": "0583",
+        "name": "Motala"
+    },
+    {
+        "id": "0584",
+        "name": "Vadstena"
+    },
+    {
+        "id": "0586",
+        "name": "Mjölby"
+    },
+    {
+        "id": "06",
+        "name": "Jönköpings län"
+    },
+    {
+        "id": "0604",
+        "name": "Aneby"
+    },
+    {
+        "id": "0617",
+        "name": "Gnosjö"
+    },
+    {
+        "id": "0642",
+        "name": "Mullsjö"
+    },
+    {
+        "id": "0643",
+        "name": "Habo"
+    },
+    {
+        "id": "0662",
+        "name": "Gislaved"
+    },
+    {
+        "id": "0665",
+        "name": "Vaggeryd"
+    },
+    {
+        "id": "0680",
+        "name": "Jönköping"
+    },
+    {
+        "id": "0682",
+        "name": "Nässjö"
+    },
+    {
+        "id": "0683",
+        "name": "Värnamo"
+    },
+    {
+        "id": "0684",
+        "name": "Sävsjö"
+    },
+    {
+        "id": "0685",
+        "name": "Vetlanda"
+    },
+    {
+        "id": "0686",
+        "name": "Eksjö"
+    },
+    {
+        "id": "0687",
+        "name": "Tranås"
+    },
+    {
+        "id": "07",
+        "name": "Kronobergs län"
+    },
+    {
+        "id": "0760",
+        "name": "Uppvidinge"
+    },
+    {
+        "id": "0761",
+        "name": "Lessebo"
+    },
+    {
+        "id": "0763",
+        "name": "Tingsryd"
+    },
+    {
+        "id": "0764",
+        "name": "Alvesta"
+    },
+    {
+        "id": "0765",
+        "name": "Älmhult"
+    },
+    {
+        "id": "0767",
+        "name": "Markaryd"
+    },
+    {
+        "id": "0780",
+        "name": "Växjö"
+    },
+    {
+        "id": "0781",
+        "name": "Ljungby"
+    },
+    {
+        "id": "08",
+        "name": "Kalmar län"
+    },
+    {
+        "id": "0821",
+        "name": "Högsby"
+    },
+    {
+        "id": "0834",
+        "name": "Torsås"
+    },
+    {
+        "id": "0840",
+        "name": "Mörbylånga"
+    },
+    {
+        "id": "0860",
+        "name": "Hultsfred"
+    },
+    {
+        "id": "0861",
+        "name": "Mönsterås"
+    },
+    {
+        "id": "0862",
+        "name": "Emmaboda"
+    },
+    {
+        "id": "0880",
+        "name": "Kalmar"
+    },
+    {
+        "id": "0881",
+        "name": "Nybro"
+    },
+    {
+        "id": "0882",
+        "name": "Oskarshamn"
+    },
+    {
+        "id": "0883",
+        "name": "Västervik"
+    },
+    {
+        "id": "0884",
+        "name": "Vimmerby"
+    },
+    {
+        "id": "0885",
+        "name": "Borgholm"
+    },
+    {
+        "id": "09",
+        "name": "Gotlands län"
+    },
+    {
+        "id": "0980",
+        "name": "Gotland"
+    },
+    {
+        "id": "10",
+        "name": "Blekinge län"
+    },
+    {
+        "id": "1060",
+        "name": "Olofström"
+    },
+    {
+        "id": "1080",
+        "name": "Karlskrona"
+    },
+    {
+        "id": "1081",
+        "name": "Ronneby"
+    },
+    {
+        "id": "1082",
+        "name": "Karlshamn"
+    },
+    {
+        "id": "1083",
+        "name": "Sölvesborg"
+    },
+    {
+        "id": "12",
+        "name": "Skåne län"
+    },
+    {
+        "id": "1214",
+        "name": "Svalöv"
+    },
+    {
+        "id": "1230",
+        "name": "Staffanstorp"
+    },
+    {
+        "id": "1231",
+        "name": "Burlöv"
+    },
+    {
+        "id": "1233",
+        "name": "Vellinge"
+    },
+    {
+        "id": "1256",
+        "name": "Östra Göinge"
+    },
+    {
+        "id": "1257",
+        "name": "Örkelljunga"
+    },
+    {
+        "id": "1260",
+        "name": "Bjuv"
+    },
+    {
+        "id": "1261",
+        "name": "Kävlinge"
+    },
+    {
+        "id": "1262",
+        "name": "Lomma"
+    },
+    {
+        "id": "1263",
+        "name": "Svedala"
+    },
+    {
+        "id": "1264",
+        "name": "Skurup"
+    },
+    {
+        "id": "1265",
+        "name": "Sjöbo"
+    },
+    {
+        "id": "1266",
+        "name": "Hörby"
+    },
+    {
+        "id": "1267",
+        "name": "Höör"
+    },
+    {
+        "id": "1270",
+        "name": "Tomelilla"
+    },
+    {
+        "id": "1272",
+        "name": "Bromölla"
+    },
+    {
+        "id": "1273",
+        "name": "Osby"
+    },
+    {
+        "id": "1275",
+        "name": "Perstorp"
+    },
+    {
+        "id": "1276",
+        "name": "Klippan"
+    },
+    {
+        "id": "1277",
+        "name": "Åstorp"
+    },
+    {
+        "id": "1278",
+        "name": "Båstad"
+    },
+    {
+        "id": "1280",
+        "name": "Malmö"
+    },
+    {
+        "id": "1281",
+        "name": "Lund"
+    },
+    {
+        "id": "1282",
+        "name": "Landskrona"
+    },
+    {
+        "id": "1283",
+        "name": "Helsingborg"
+    },
+    {
+        "id": "1284",
+        "name": "Höganäs"
+    },
+    {
+        "id": "1285",
+        "name": "Eslöv"
+    },
+    {
+        "id": "1286",
+        "name": "Ystad"
+    },
+    {
+        "id": "1287",
+        "name": "Trelleborg"
+    },
+    {
+        "id": "1290",
+        "name": "Kristianstad"
+    },
+    {
+        "id": "1291",
+        "name": "Simrishamn"
+    },
+    {
+        "id": "1292",
+        "name": "Ängelholm"
+    },
+    {
+        "id": "1293",
+        "name": "Hässleholm"
+    },
+    {
+        "id": "13",
+        "name": "Hallands län"
+    },
+    {
+        "id": "1315",
+        "name": "Hylte"
+    },
+    {
+        "id": "1380",
+        "name": "Halmstad"
+    },
+    {
+        "id": "1381",
+        "name": "Laholm"
+    },
+    {
+        "id": "1382",
+        "name": "Falkenberg"
+    },
+    {
+        "id": "1383",
+        "name": "Varberg"
+    },
+    {
+        "id": "1384",
+        "name": "Kungsbacka"
+    },
+    {
+        "id": "14",
+        "name": "Västra Götalands län"
+    },
+    {
+        "id": "1401",
+        "name": "Härryda"
+    },
+    {
+        "id": "1402",
+        "name": "Partille"
+    },
+    {
+        "id": "1407",
+        "name": "Öckerö"
+    },
+    {
+        "id": "1415",
+        "name": "Stenungsund"
+    },
+    {
+        "id": "1419",
+        "name": "Tjörn"
+    },
+    {
+        "id": "1421",
+        "name": "Orust"
+    },
+    {
+        "id": "1427",
+        "name": "Sotenäs"
+    },
+    {
+        "id": "1430",
+        "name": "Munkedal"
+    },
+    {
+        "id": "1435",
+        "name": "Tanum"
+    },
+    {
+        "id": "1438",
+        "name": "Dals-Ed"
+    },
+    {
+        "id": "1439",
+        "name": "Färgelanda"
+    },
+    {
+        "id": "1440",
+        "name": "Ale"
+    },
+    {
+        "id": "1441",
+        "name": "Lerum"
+    },
+    {
+        "id": "1442",
+        "name": "Vårgårda"
+    },
+    {
+        "id": "1443",
+        "name": "Bollebygd"
+    },
+    {
+        "id": "1444",
+        "name": "Grästorp"
+    },
+    {
+        "id": "1445",
+        "name": "Essunga"
+    },
+    {
+        "id": "1446",
+        "name": "Karlsborg"
+    },
+    {
+        "id": "1447",
+        "name": "Gullspång"
+    },
+    {
+        "id": "1452",
+        "name": "Tranemo"
+    },
+    {
+        "id": "1460",
+        "name": "Bengtsfors"
+    },
+    {
+        "id": "1461",
+        "name": "Mellerud"
+    },
+    {
+        "id": "1462",
+        "name": "Lilla Edet"
+    },
+    {
+        "id": "1463",
+        "name": "Mark"
+    },
+    {
+        "id": "1465",
+        "name": "Svenljunga"
+    },
+    {
+        "id": "1466",
+        "name": "Herrljunga"
+    },
+    {
+        "id": "1470",
+        "name": "Vara"
+    },
+    {
+        "id": "1471",
+        "name": "Götene"
+    },
+    {
+        "id": "1472",
+        "name": "Tibro"
+    },
+    {
+        "id": "1473",
+        "name": "Töreboda"
+    },
+    {
+        "id": "1480",
+        "name": "Göteborg"
+    },
+    {
+        "id": "1481",
+        "name": "Mölndal"
+    },
+    {
+        "id": "1482",
+        "name": "Kungälv"
+    },
+    {
+        "id": "1484",
+        "name": "Lysekil"
+    },
+    {
+        "id": "1485",
+        "name": "Uddevalla"
+    },
+    {
+        "id": "1486",
+        "name": "Strömstad"
+    },
+    {
+        "id": "1487",
+        "name": "Vänersborg"
+    },
+    {
+        "id": "1488",
+        "name": "Trollhättan"
+    },
+    {
+        "id": "1489",
+        "name": "Alingsås"
+    },
+    {
+        "id": "1490",
+        "name": "Borås"
+    },
+    {
+        "id": "1491",
+        "name": "Ulricehamn"
+    },
+    {
+        "id": "1492",
+        "name": "Åmål"
+    },
+    {
+        "id": "1493",
+        "name": "Mariestad"
+    },
+    {
+        "id": "1494",
+        "name": "Lidköping"
+    },
+    {
+        "id": "1495",
+        "name": "Skara"
+    },
+    {
+        "id": "1496",
+        "name": "Skövde"
+    },
+    {
+        "id": "1497",
+        "name": "Hjo"
+    },
+    {
+        "id": "1498",
+        "name": "Tidaholm"
+    },
+    {
+        "id": "1499",
+        "name": "Falköping"
+    },
+    {
+        "id": "17",
+        "name": "Värmlands län"
+    },
+    {
+        "id": "1715",
+        "name": "Kil"
+    },
+    {
+        "id": "1730",
+        "name": "Eda"
+    },
+    {
+        "id": "1737",
+        "name": "Torsby"
+    },
+    {
+        "id": "1760",
+        "name": "Storfors"
+    },
+    {
+        "id": "1761",
+        "name": "Hammarö"
+    },
+    {
+        "id": "1762",
+        "name": "Munkfors"
+    },
+    {
+        "id": "1763",
+        "name": "Forshaga"
+    },
+    {
+        "id": "1764",
+        "name": "Grums"
+    },
+    {
+        "id": "1765",
+        "name": "Årjäng"
+    },
+    {
+        "id": "1766",
+        "name": "Sunne"
+    },
+    {
+        "id": "1780",
+        "name": "Karlstad"
+    },
+    {
+        "id": "1781",
+        "name": "Kristinehamn"
+    },
+    {
+        "id": "1782",
+        "name": "Filipstad"
+    },
+    {
+        "id": "1783",
+        "name": "Hagfors"
+    },
+    {
+        "id": "1784",
+        "name": "Arvika"
+    },
+    {
+        "id": "1785",
+        "name": "Säffle"
+    },
+    {
+        "id": "18",
+        "name": "Örebro län"
+    },
+    {
+        "id": "1814",
+        "name": "Lekeberg"
+    },
+    {
+        "id": "1860",
+        "name": "Laxå"
+    },
+    {
+        "id": "1861",
+        "name": "Hallsberg"
+    },
+    {
+        "id": "1862",
+        "name": "Degerfors"
+    },
+    {
+        "id": "1863",
+        "name": "Hällefors"
+    },
+    {
+        "id": "1864",
+        "name": "Ljusnarsberg"
+    },
+    {
+        "id": "1880",
+        "name": "Örebro"
+    },
+    {
+        "id": "1881",
+        "name": "Kumla"
+    },
+    {
+        "id": "1882",
+        "name": "Askersund"
+    },
+    {
+        "id": "1883",
+        "name": "Karlskoga"
+    },
+    {
+        "id": "1884",
+        "name": "Nora"
+    },
+    {
+        "id": "1885",
+        "name": "Lindesberg"
+    },
+    {
+        "id": "19",
+        "name": "Västmanlands län"
+    },
+    {
+        "id": "1904",
+        "name": "Skinnskatteberg"
+    },
+    {
+        "id": "1907",
+        "name": "Surahammar"
+    },
+    {
+        "id": "1960",
+        "name": "Kungsör"
+    },
+    {
+        "id": "1961",
+        "name": "Hallstahammar"
+    },
+    {
+        "id": "1962",
+        "name": "Norberg"
+    },
+    {
+        "id": "1980",
+        "name": "Västerås"
+    },
+    {
+        "id": "1981",
+        "name": "Sala"
+    },
+    {
+        "id": "1982",
+        "name": "Fagersta"
+    },
+    {
+        "id": "1983",
+        "name": "Köping"
+    },
+    {
+        "id": "1984",
+        "name": "Arboga"
+    },
+    {
+        "id": "20",
+        "name": "Dalarnas län"
+    },
+    {
+        "id": "2021",
+        "name": "Vansbro"
+    },
+    {
+        "id": "2023",
+        "name": "Malung-Sälen"
+    },
+    {
+        "id": "2026",
+        "name": "Gagnef"
+    },
+    {
+        "id": "2029",
+        "name": "Leksand"
+    },
+    {
+        "id": "2031",
+        "name": "Rättvik"
+    },
+    {
+        "id": "2034",
+        "name": "Orsa"
+    },
+    {
+        "id": "2039",
+        "name": "Älvdalen"
+    },
+    {
+        "id": "2061",
+        "name": "Smedjebacken"
+    },
+    {
+        "id": "2062",
+        "name": "Mora"
+    },
+    {
+        "id": "2080",
+        "name": "Falun"
+    },
+    {
+        "id": "2081",
+        "name": "Borlänge"
+    },
+    {
+        "id": "2082",
+        "name": "Säter"
+    },
+    {
+        "id": "2083",
+        "name": "Hedemora"
+    },
+    {
+        "id": "2084",
+        "name": "Avesta"
+    },
+    {
+        "id": "2085",
+        "name": "Ludvika"
+    },
+    {
+        "id": "21",
+        "name": "Gävleborgs län"
+    },
+    {
+        "id": "2101",
+        "name": "Ockelbo"
+    },
+    {
+        "id": "2104",
+        "name": "Hofors"
+    },
+    {
+        "id": "2121",
+        "name": "Ovanåker"
+    },
+    {
+        "id": "2132",
+        "name": "Nordanstig"
+    },
+    {
+        "id": "2161",
+        "name": "Ljusdal"
+    },
+    {
+        "id": "2180",
+        "name": "Gävle"
+    },
+    {
+        "id": "2181",
+        "name": "Sandviken"
+    },
+    {
+        "id": "2182",
+        "name": "Söderhamn"
+    },
+    {
+        "id": "2183",
+        "name": "Bollnäs"
+    },
+    {
+        "id": "2184",
+        "name": "Hudiksvall"
+    },
+    {
+        "id": "22",
+        "name": "Västernorrlands län"
+    },
+    {
+        "id": "2260",
+        "name": "Ånge"
+    },
+    {
+        "id": "2262",
+        "name": "Timrå"
+    },
+    {
+        "id": "2280",
+        "name": "Härnösand"
+    },
+    {
+        "id": "2281",
+        "name": "Sundsvall"
+    },
+    {
+        "id": "2282",
+        "name": "Kramfors"
+    },
+    {
+        "id": "2283",
+        "name": "Sollefteå"
+    },
+    {
+        "id": "2284",
+        "name": "Örnsköldsvik"
+    },
+    {
+        "id": "23",
+        "name": "Jämtlands län"
+    },
+    {
+        "id": "2303",
+        "name": "Ragunda"
+    },
+    {
+        "id": "2305",
+        "name": "Bräcke"
+    },
+    {
+        "id": "2309",
+        "name": "Krokom"
+    },
+    {
+        "id": "2313",
+        "name": "Strömsund"
+    },
+    {
+        "id": "2321",
+        "name": "Åre"
+    },
+    {
+        "id": "2326",
+        "name": "Berg"
+    },
+    {
+        "id": "2361",
+        "name": "Härjedalen"
+    },
+    {
+        "id": "2380",
+        "name": "Östersund"
+    },
+    {
+        "id": "24",
+        "name": "Västerbottens län"
+    },
+    {
+        "id": "2401",
+        "name": "Nordmaling"
+    },
+    {
+        "id": "2403",
+        "name": "Bjurholm"
+    },
+    {
+        "id": "2404",
+        "name": "Vindeln"
+    },
+    {
+        "id": "2409",
+        "name": "Robertsfors"
+    },
+    {
+        "id": "2417",
+        "name": "Norsjö"
+    },
+    {
+        "id": "2418",
+        "name": "Malå"
+    },
+    {
+        "id": "2421",
+        "name": "Storuman"
+    },
+    {
+        "id": "2422",
+        "name": "Sorsele"
+    },
+    {
+        "id": "2425",
+        "name": "Dorotea"
+    },
+    {
+        "id": "2460",
+        "name": "Vännäs"
+    },
+    {
+        "id": "2462",
+        "name": "Vilhelmina"
+    },
+    {
+        "id": "2463",
+        "name": "Åsele"
+    },
+    {
+        "id": "2480",
+        "name": "Umeå"
+    },
+    {
+        "id": "2481",
+        "name": "Lycksele"
+    },
+    {
+        "id": "2482",
+        "name": "Skellefteå"
+    },
+    {
+        "id": "25",
+        "name": "Norrbottens län"
+    },
+    {
+        "id": "2505",
+        "name": "Arvidsjaur"
+    },
+    {
+        "id": "2506",
+        "name": "Arjeplog"
+    },
+    {
+        "id": "2510",
+        "name": "Jokkmokk"
+    },
+    {
+        "id": "2513",
+        "name": "Överkalix"
+    },
+    {
+        "id": "2514",
+        "name": "Kalix"
+    },
+    {
+        "id": "2518",
+        "name": "Övertorneå"
+    },
+    {
+        "id": "2521",
+        "name": "Pajala"
+    },
+    {
+        "id": "2523",
+        "name": "Gällivare"
+    },
+    {
+        "id": "2560",
+        "name": "Älvsbyn"
+    },
+    {
+        "id": "2580",
+        "name": "Luleå"
+    },
+    {
+        "id": "2581",
+        "name": "Piteå"
+    },
+    {
+        "id": "2582",
+        "name": "Boden"
+    },
+    {
+        "id": "2583",
+        "name": "Haparanda"
+    },
+    {
+        "id": "2584",
+        "name": "Kiruna"
+    }
+]

--- a/dept44-starter/src/test/java/se/sundsvall/dept44/util/MunicipalityUtilsTest.java
+++ b/dept44-starter/src/test/java/se/sundsvall/dept44/util/MunicipalityUtilsTest.java
@@ -1,0 +1,127 @@
+package se.sundsvall.dept44.util;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.apache.commons.lang3.StringUtils.length;
+import static org.apache.commons.lang3.StringUtils.trim;
+import static org.apache.commons.lang3.math.NumberUtils.isDigits;
+import static org.assertj.core.api.Assertions.assertThat;
+import static se.sundsvall.dept44.test.annotation.resource.Load.ResourceType.STRING;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import se.sundsvall.dept44.test.annotation.resource.Load;
+import se.sundsvall.dept44.test.extension.ResourceLoaderExtension;
+import se.sundsvall.dept44.util.MunicipalityUtils.Municipality;
+
+@ExtendWith(ResourceLoaderExtension.class)
+class MunicipalityUtilsTest {
+
+	private static final String TEST_JSON_FILE = "data/municipality.json";
+	private static final Integer EXPECTED_NUMBER_OF_MUNICIPALITY_RECORDS = 311;
+
+	@Test
+	void validFileContent(@Load(value = TEST_JSON_FILE, as = STRING) final String json) throws Exception {
+		assertThat(new ObjectMapper().readValue(json, new TypeReference<List<Municipality>>() {}))
+			.hasSize(EXPECTED_NUMBER_OF_MUNICIPALITY_RECORDS)
+			.allMatch(municipality -> isNotBlank(municipality.id()))
+			.allMatch(municipality -> isNotBlank(municipality.name()))
+			.allMatch(municipality -> isDigits(municipality.id()))
+			.allMatch(municipality -> hasNoSurroundingWhitespace(municipality.name()));
+	}
+
+	@Test
+	void findById() {
+
+		// Call
+		final var municipality = MunicipalityUtils.findById("2281");
+
+		// Verification
+		assertThat(municipality).isNotNull();
+		assertThat(municipality.id()).isEqualTo("2281");
+		assertThat(municipality.name()).isEqualTo("Sundsvall");
+	}
+
+	@Test
+	void findByIdNotFound() {
+
+		// Call
+		final var municipality = MunicipalityUtils.findById("666");
+
+		// Verification
+		assertThat(municipality).isNull();
+	}
+
+	@Test
+	void findByName() {
+
+		// Call
+		final var municipality = MunicipalityUtils.findByName("Sundsvall");
+
+		// Verification
+		assertThat(municipality).isNotNull();
+		assertThat(municipality.id()).isEqualTo("2281");
+		assertThat(municipality.name()).isEqualTo("Sundsvall");
+	}
+
+	@Test
+	void findByNameNotFound() {
+
+		// Call
+		final var municipality = MunicipalityUtils.findByName("Sörbäcken");
+
+		// Verification
+		assertThat(municipality).isNull();
+	}
+
+	@Test
+	void findByNameCaseInsensitive() {
+
+		// Call
+		final var municipality = MunicipalityUtils.findByName("sUnDsVaLl");
+
+		// Verification
+		assertThat(municipality).isNotNull();
+		assertThat(municipality.id()).isEqualTo("2281");
+		assertThat(municipality.name()).isEqualTo("Sundsvall");
+	}
+
+	@Test
+	void existsById() {
+		assertThat(MunicipalityUtils.existsById("2281")).isTrue();
+	}
+
+	@Test
+	void existsByIdNotFound() {
+		assertThat(MunicipalityUtils.existsById("666")).isFalse();
+	}
+
+	@Test
+	void existsByName() {
+		assertThat(MunicipalityUtils.existsByName("Sundsvall")).isTrue();
+	}
+
+	@Test
+	void existsByNameCaseInsensitive() {
+		assertThat(MunicipalityUtils.existsByName("sUnDsVaLl")).isTrue();
+	}
+
+	@Test
+	void existsByNameNotFound() {
+		assertThat(MunicipalityUtils.existsByName("Sörbäcken")).isFalse();
+	}
+
+	@Test
+	void findAll() {
+		assertThat(MunicipalityUtils.findAll()).hasSize(EXPECTED_NUMBER_OF_MUNICIPALITY_RECORDS);
+	}
+
+	private boolean hasNoSurroundingWhitespace(final String string) {
+		return trim(string).length() == length(string);
+	}
+}


### PR DESCRIPTION
Added a utility class for municipality ID:s. The utility class has methods for fetching municipality name (e.g. "Sundsvall") by ID. And the other way around: Fetch ID based on the name.

The existing `@ValidMunicipalityId`-annotation is also refactored to use this new utility class. 
I.e. by using this annotation, you will validate that the municipalityID is a real existing ID. I.e. 1234, 6666, 9999 or similar dummy data will not work any more. From now on it must match one of the ID:s defined in: https://www.scb.se/hitta-statistik/regional-statistik-och-kartor/regionala-indelningar/lan-och-kommuner/lan-och-kommuner-i-kodnummerordning/