### PR TITLE
UF-5002 - Minor issue in example/reference application

### DIFF
--- a/dept44-example/src/integration-test/resources/PetInventoryIT/__files/test03_getPetInventoryItemNotFound/mappings/api-petstore-pet.json
+++ b/dept44-example/src/integration-test/resources/PetInventoryIT/__files/test03_getPetInventoryItemNotFound/mappings/api-petstore-pet.json
@@ -15,10 +15,7 @@
 		},
 		"status": 404,
 		"jsonBody": {
-			"status": {
-				"statusCode": 404,
-				"reasonPhrase": "Not found"
-			},
+			"status": 404,
 			"title": "No pet found",
 			"detail": "No pet with id 666 was found!"
 		}

--- a/dept44-example/src/integration-test/resources/PetInventoryIT/__files/test03_getPetInventoryItemNotFound/response.json
+++ b/dept44-example/src/integration-test/resources/PetInventoryIT/__files/test03_getPetInventoryItemNotFound/response.json
@@ -1,5 +1,5 @@
 {
-	"detail": "petstore error: {status=404 Not Found, title=Unknown error}",
+	"detail": "petstore error: {detail=No pet with id 666 was found!, status=404 Not Found, title=No pet found}",
 	"status": 404,
 	"title": "Not Found"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -198,11 +198,6 @@
 			</dependency>
 			<dependency>
 				<groupId>se.sundsvall.dept44</groupId>
-				<artifactId>dept44-starter-resttemplate</artifactId>
-				<version>1.30-SNAPSHOT</version>
-			</dependency>
-			<dependency>
-				<groupId>se.sundsvall.dept44</groupId>
 				<artifactId>dept44-starter-test</artifactId>
 				<version>1.36-SNAPSHOT</version>
 			</dependency>


### PR DESCRIPTION
Fixes a Wiremock mapping and the expected response for the example/reference application that caused an exception in the Feign problem decoder.

Also, removes the POM reference to the deprecated (and removed) RestTemplate dept44 starter.