### PR TITLE
UF-5054 - Expose response headers in app tests

### DIFF
--- a/dept44-starter-test/src/main/java/se/sundsvall/dept44/test/AbstractAppTest.java
+++ b/dept44-starter-test/src/main/java/se/sundsvall/dept44/test/AbstractAppTest.java
@@ -68,6 +68,7 @@ public abstract class AbstractAppTest {
 	private String mappingPath;
 	private String servicePath;
 	private String responseBody;
+	private HttpHeaders responseHeaders;
 	private HttpMethod method;
 	private HttpStatus expectedResponseStatus;
 	private HttpHeaders expectedResponseHeaders;
@@ -225,6 +226,7 @@ public abstract class AbstractAppTest {
 		// Call service and fetch response.
 		final var response = this.restTemplate.exchange(this.servicePath, this.method, restTemplateRequest(mediaType, this.requestBody), String.class);
 		this.responseBody = response.getBody();
+		this.responseHeaders = response.getHeaders();
 
 		if (nonNull(this.expectedResponseHeaders)) {
 			this.expectedResponseHeaders.entrySet().stream().forEach(expectedHeader -> {
@@ -265,6 +267,26 @@ public abstract class AbstractAppTest {
 	}
 
 	/**
+	 * Returns the response body mapped to the provided class.
+	 *
+	 * @param clazz the class to map the response body to
+	 * @return the mapped response
+	 */
+	public <T> T getResponseBody(final Class<T> clazz) throws JsonProcessingException, ClassNotFoundException {
+		return andReturnBody(clazz);
+	}
+
+	/**
+	 * Returns the response body mapped to the provided type reference.
+	 *
+	 * @param typeReference the type reference to map the response body to
+	 * @return the mapped response
+	 */
+	public <T> T getResponseBody(final TypeReference<T> typeReference) throws JsonProcessingException {
+		return andReturnBody(typeReference);
+	}
+
+	/**
 	 * Method returns the received server response mapped to the sent in class
 	 *
 	 * @param clazz class to map response to
@@ -282,6 +304,15 @@ public abstract class AbstractAppTest {
 	 */
 	public <T> T andReturnBody(final TypeReference<T> typeReference) throws JsonProcessingException {
 		return JSON_MAPPER.readValue(this.responseBody, typeReference);
+	}
+
+	/**
+	 * Returns the response headers.
+	 *
+	 * @return the response headers
+	 */
+	public HttpHeaders getResponseHeaders() {
+		return responseHeaders;
 	}
 
 	public AbstractAppTest andVerifyThat(final Callable<Boolean> conditionIsMet) {

--- a/dept44-starter-test/src/test/java/se/sundsvall/dept44/test/AbstractAppTestTest.java
+++ b/dept44-starter-test/src/test/java/se/sundsvall/dept44/test/AbstractAppTestTest.java
@@ -208,19 +208,25 @@ class AbstractAppTestTest {
 		when(wiremockMock.listAllStubMappings()).thenReturn(new ListStubMappingsResult(List.of(new StubMapping()), null));
 
 		// Call
-		final var instance = appTest.setupCall()
+		final var call = appTest.setupCall()
 			.withExtensions(extensionMock)
 			.withServicePath("/some/path")
 			.withHttpMethod(PUT)
 			.withExpectedResponseStatus(NO_CONTENT)
 			.withMaxVerificationDelayInSeconds(5)
-			.sendRequestAndVerifyResponse()
-			.andReturnBody(TestBody.class);
+			.sendRequestAndVerifyResponse();
+
+		final var instance = call.getResponseBody(TestBody.class);
+		final var headers = call.getResponseHeaders();
 
 		// Verification
 		assertThat(instance).isNotNull();
 		assertThat(instance.getKey()).isEqualTo("this-is-key");
 		assertThat(instance.getValue()).isEqualTo("this-is-value");
+
+		assertThat(headers).isNotNull();
+		assertThat(headers.get("responseHeader")).containsOnly("responseValue");
+
 		verify(restTemplateMock).exchange(eq("/some/path"), eq(PUT), httpEntityCaptor.capture(), eq(String.class));
 		verify(wiremockMock, times(2)).loadMappingsUsing(any(JsonFileMappingsSource.class));
 		verify(wiremockMock).findAllUnmatchedRequests();


### PR DESCRIPTION
Adds the possibility of extracting response headers in app tests, i.e. instead of using `withExpectedResponseHeader(...)`, one could use something like:

```
var call = setupCall()
    .withServicePath("...")
    ...
    .sendRequestAndVerifyResponse();

var headers = call.getResponseHeaders();
(...further header processing/verification...)
```

In addition, adds two methods: `getResponseBody(Class<T>)` and `getResponseBody(TypeReference<T>)`, that in practice just relay calls to the corresponding `andReturnBody(...)` method, but where method naming aligns better with `getResponseHeaders(...)` when used like in the example above.