### PR TITLE
UF5055 - Fix Spring Cloud Kubernetes breaking change

### DIFF
--- a/dept44-starter/src/main/resources/config/bootstrap.properties
+++ b/dept44-starter/src/main/resources/config/bootstrap.properties
@@ -9,4 +9,4 @@ spring.cloud.config.password=${SPRING_CLOUD_CONFIG_PASSWORD:}
 ##############################################
 # Cloud kubernetes settings
 ##############################################
-spring.cloud.kubernetes.enabled=false
+spring.main.cloud-platform=none


### PR DESCRIPTION
The property `spring.cloud.kubernetes.enabled` has been deprecated and is replaced by setting `spring.main.cloud-platform` to `none`.

(Normally, the framework relies on the `org.springframework.boot.autoconfigure.condition.ConditionalOnCloudPlatform` conditional, but having explicitly disabled it in previous versions of dept44 it's suggested we stay on that path for now)