### PR TITLE
UF-5326 - Bump deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,11 +109,11 @@
 
 		<!-- Dependency versions -->
 		<apache-commons.version>3.12.0</apache-commons.version>
-		<logbook.version>3.0.0-RC.2</logbook.version>
+		<logbook.version>3.0.0</logbook.version>
 		<problem.version>0.27.1</problem.version> <!-- Use different versions of problem and problem-spring-XYZ libraries, because of reasons... -->
 		<problem-spring-web.version>0.29.1</problem-spring-web.version>
 		<springdoc.version>2.1.0</springdoc.version>
-		<spring-cloud.version>2022.0.2</spring-cloud.version>
+		<spring-cloud.version>2022.0.3</spring-cloud.version>
 		<bean-matchers.version>0.14</bean-matchers.version>
 		<json-unit.version>2.38.0</json-unit.version>
 		<logback-gelf.version>4.0.2</logback-gelf.version>


### PR DESCRIPTION
Bumps Spring Cloud to 2022.0.3 (primarily to get Feign 12.3 with proper Jakarta support for SOAP). Also bumps Logbook to 3.0.0