### PR TITLE
UF-5561: Made stub verification and stub reset optional

### DIFF
--- a/dept44-starter-test/src/main/java/se/sundsvall/dept44/test/AbstractAppTest.java
+++ b/dept44-starter-test/src/main/java/se/sundsvall/dept44/test/AbstractAppTest.java
@@ -220,6 +220,10 @@ public abstract class AbstractAppTest {
 	}
 
 	public AbstractAppTest sendRequestAndVerifyResponse(final MediaType mediaType) {
+		return sendRequestAndVerifyResponse(mediaType, true);
+	}
+
+	public AbstractAppTest sendRequestAndVerifyResponse(final MediaType mediaType, boolean verifyStubsAndResetWiremock) {
 		logger.info(getTestMethodName());
 
 		// Call service and fetch response.
@@ -248,6 +252,14 @@ public abstract class AbstractAppTest {
 			assertThat(this.responseBody).isNull();
 		}
 
+		if (verifyStubsAndResetWiremock) {
+			verifyStubsAndResetWiremock();
+		}
+
+		return this;
+	}
+
+	public AbstractAppTest verifyStubsAndResetWiremock() {
 		await()
 			.atMost(maxVerificationDelayInSeconds, SECONDS)
 			.pollDelay(0, SECONDS)

--- a/dept44-starter-test/src/test/java/se/sundsvall/dept44/test/AbstractAppTestTest.java
+++ b/dept44-starter-test/src/test/java/se/sundsvall/dept44/test/AbstractAppTestTest.java
@@ -1,6 +1,7 @@
 package se.sundsvall.dept44.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
@@ -40,6 +41,7 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.extension.ResponseDefinitionTransformer;
 import com.github.tomakehurst.wiremock.standalone.JsonFileMappingsSource;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 
 import net.javacrumbs.jsonunit.core.Option;
 import se.sundsvall.dept44.test.supportfiles.AppTestImplementation;
@@ -265,5 +267,21 @@ class AbstractAppTestTest {
 
 		assertThat(httpEntityCaptor.getValue().getHeaders()).containsEntry(CONTENT_TYPE, List.of(APPLICATION_JSON_VALUE));
 		assertThat(httpEntityCaptor.getValue().getHeaders()).containsEntry("x-test-case", List.of("AppTestImplementation.testDELETECall"));
+	}
+
+	@Test
+	void verifyAllStubsWhenStubNotExecuted() throws Exception {
+		// Setup
+		final var url = "http://url.address";
+
+		// Mock
+		when(wiremockMock.listAllStubMappings()).thenReturn(new ListStubMappingsResult(List.of(new StubMapping()), null));
+		when(wiremockMock.findAllUnmatchedRequests()).thenReturn(List.of(new LoggedRequest(url, null, null, null, null, null, false, null, null, null)));
+		
+		// Call
+		final var exception = assertThrows(AssertionError.class, () -> appTest.verifyAllStubs());
+		
+		// Verification
+		assertThat(exception.getMessage()).isEqualTo("The following requests was not matched: " + List.of(url));
 	}
 }


### PR DESCRIPTION
- Implemented solution to make stub verification and stub reset optional for sendRequestAndVerifyResponse method to allow the possibility of doing the verification and reset later in the test flow (for example when testing asynchronous calls).