### PR TITLE
UF-5986 - Set git-commit-id-maven-plugin version

### DIFF
--- a/dept44-service-parent/pom.xml
+++ b/dept44-service-parent/pom.xml
@@ -339,6 +339,7 @@
 			<plugin>
 				<groupId>io.github.git-commit-id</groupId>
 				<artifactId>git-commit-id-maven-plugin</artifactId>
+				<version>${git-commit-id-maven-plugin.version}</version>
 				<executions>
 					<execution>
 						<id>get-the-git-infos</id>


### PR DESCRIPTION
Explicitly sets the git-commit-id-maven-plugin version, to get Maven to stop complaining about it.