### PR TITLE
UF-6056 - Ability to override Feign default OAuth2 scopes

### DIFF
--- a/dept44-starter-feign/src/main/java/se/sundsvall/dept44/configuration/feign/FeignMultiCustomizer.java
+++ b/dept44-starter-feign/src/main/java/se/sundsvall/dept44/configuration/feign/FeignMultiCustomizer.java
@@ -53,7 +53,7 @@ public class FeignMultiCustomizer {
 	}
 
 	/**
-	 * Method for creating a RetryableOAuth2InterceptorForClientRegistration with default scopeset, which includes the
+	 * Method for creating a RetryableOAuth2InterceptorForClientRegistration with default scope-set, which includes the
 	 * device-scope needed to ensure correct handling of multiple instances in WSO2. The device-scope will be merged with
 	 * the scopes defined in the clientRegistration.
 	 *
@@ -61,8 +61,20 @@ public class FeignMultiCustomizer {
 	 * @return FeignMultiCustomizer with a configured RetryableOAuth2InterceptorForClientRegistration
 	 */
 	public FeignMultiCustomizer withRetryableOAuth2InterceptorForClientRegistration(final ClientRegistration clientRegistration) {
+		return withRetryableOAuth2InterceptorForClientRegistration(clientRegistration, Set.of("device_" + UUID.randomUUID()));
+	}
+
+	/**
+	 * Method for creating a RetryableOAuth2InterceptorForClientRegistration with a set of extra scopes (may be empty).
+	 * Any extra scopes will be merged with the scopes defined in the clientRegistration.
+	 *
+	 * @param clientRegistration containing authorization information for the client
+	 * @param extraScopes a set of extra scopes
+	 * @return FeignMultiCustomizer with a configured RetryableOAuth2InterceptorForClientRegistration
+	 */
+	public FeignMultiCustomizer withRetryableOAuth2InterceptorForClientRegistration(final ClientRegistration clientRegistration, final Set<String> extraScopes) {
 		return withCustomizer(builder -> {
-			final var oAuth2RequestInterceptor = new OAuth2RequestInterceptor(clientRegistration, Set.of("device_" + UUID.randomUUID()));
+			final var oAuth2RequestInterceptor = new OAuth2RequestInterceptor(clientRegistration, extraScopes);
 			builder.requestInterceptor(oAuth2RequestInterceptor);
 			builder.retryer(new ActionRetryer(oAuth2RequestInterceptor::removeToken, 1));
 		});


### PR DESCRIPTION
Adds the ability to override/clear out Feign default OAuth2 scopes.

(The case for this is that the Kivra API rejects requests with our default `device_<UUID>` scope, and we need to be able to remove it)