### PR TITLE
UF-6245 - BASE64-validator and blank strings

### DIFF
--- a/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidBase64ConstraintValidator.java
+++ b/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidBase64ConstraintValidator.java
@@ -2,6 +2,7 @@ package se.sundsvall.dept44.common.validators.annotation.impl;
 
 import static java.util.Objects.isNull;
 import static java.util.Optional.ofNullable;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.springframework.util.ReflectionUtils.findMethod;
 
 import java.lang.reflect.Method;
@@ -13,7 +14,7 @@ import jakarta.validation.ConstraintValidatorContext;
 import se.sundsvall.dept44.common.validators.annotation.ValidBase64;
 
 /**
- * Defines the logic to validate that a string is a valid base64-string.
+ * Defines the logic to validate that a string is a valid non-blank base64-string.
  */
 public class ValidBase64ConstraintValidator extends AbstractValidator implements ConstraintValidator<ValidBase64, String> {
 
@@ -30,6 +31,9 @@ public class ValidBase64ConstraintValidator extends AbstractValidator implements
 	public boolean isValid(final String value, final ConstraintValidatorContext context) {
 		if (isNull(value) && nullable) {
 			return true;
+		}
+		if (isBlank(value)) {
+			return false;
 		}
 		return isValidBase64(value);
 	}

--- a/dept44-common-validators/src/test/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidBase64ConstraintValidatorTest.java
+++ b/dept44-common-validators/src/test/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidBase64ConstraintValidatorTest.java
@@ -43,7 +43,7 @@ class ValidBase64ConstraintValidatorTest {
 	}
 
 	@Test
-	void nullBase64WnenNullableIsFalse() {
+	void nullBase64WhenNullableIsFalse() {
 		validator.initialize(mockAnnotation);
 
 		assertThat(validator.isValid(null)).isFalse();
@@ -53,7 +53,7 @@ class ValidBase64ConstraintValidatorTest {
 	}
 
 	@Test
-	void nullablenullBase64WnenNullableIsTrue() {
+	void nullBase64WhenNullableIsTrue() {
 		when(mockAnnotation.nullable()).thenReturn(true);
 
 		validator.initialize(mockAnnotation);
@@ -62,6 +62,16 @@ class ValidBase64ConstraintValidatorTest {
 		assertThat(validator.isValid(null, null)).isTrue(); // null is treated as valid.
 		assertThat(validator.isValid("not-base64-encoded")).isFalse(); // non-null and invalid values are still treated as invalid.
 		assertThat(validator.isValid("not-base64-encoded", null)).isFalse(); // non-null and invalid values are still treated as invalid.
+
+		verify(mockAnnotation).nullable();
+	}
+
+	@Test
+	void blankBase64() {
+		validator.initialize(mockAnnotation);
+
+		assertThat(validator.isValid("")).isFalse();
+		assertThat(validator.isValid("", null)).isFalse();
 
 		verify(mockAnnotation).nullable();
 	}

--- a/dept44-common-validators/src/test/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidBase64ConstraintValidatorTest.java
+++ b/dept44-common-validators/src/test/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidBase64ConstraintValidatorTest.java
@@ -7,6 +7,9 @@ import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -32,22 +35,14 @@ class ValidBase64ConstraintValidatorTest {
 		verify(mockAnnotation).nullable();
 	}
 
-	@Test
-	void invalidBase64() {
+	@ParameterizedTest
+	@NullSource
+	@ValueSource(strings = {"not-base64-encoded", ""})
+	void invalidBase64(final String value) {
 		validator.initialize(mockAnnotation);
 
-		assertThat(validator.isValid("not-base64-encoded")).isFalse();
-		assertThat(validator.isValid("not-base64-encoded", null)).isFalse();
-
-		verify(mockAnnotation).nullable();
-	}
-
-	@Test
-	void nullBase64WhenNullableIsFalse() {
-		validator.initialize(mockAnnotation);
-
-		assertThat(validator.isValid(null)).isFalse();
-		assertThat(validator.isValid(null, null)).isFalse();
+		assertThat(validator.isValid(value)).isFalse();
+		assertThat(validator.isValid(value, null)).isFalse();
 
 		verify(mockAnnotation).nullable();
 	}
@@ -62,16 +57,6 @@ class ValidBase64ConstraintValidatorTest {
 		assertThat(validator.isValid(null, null)).isTrue(); // null is treated as valid.
 		assertThat(validator.isValid("not-base64-encoded")).isFalse(); // non-null and invalid values are still treated as invalid.
 		assertThat(validator.isValid("not-base64-encoded", null)).isFalse(); // non-null and invalid values are still treated as invalid.
-
-		verify(mockAnnotation).nullable();
-	}
-
-	@Test
-	void blankBase64() {
-		validator.initialize(mockAnnotation);
-
-		assertThat(validator.isValid("")).isFalse();
-		assertThat(validator.isValid("", null)).isFalse();
 
 		verify(mockAnnotation).nullable();
 	}


### PR DESCRIPTION
Changes the `@ValidBase64` validation logic so that blank strings aren't accepted as valid anymore