### PR TITLE
UF-6893 - Merge Logbook excludes

### DIFF
--- a/dept44-starter/src/main/java/se/sundsvall/dept44/configuration/LogbookConfiguration.java
+++ b/dept44-starter/src/main/java/se/sundsvall/dept44/configuration/LogbookConfiguration.java
@@ -7,12 +7,15 @@ import static se.sundsvall.dept44.logbook.filter.BodyFilterProvider.passwordFilt
 import static se.sundsvall.dept44.logbook.filter.ResponseFilterDefinition.fileAttachmentFilter;
 import static se.sundsvall.dept44.util.EncodingUtils.fixDoubleEncodedUTF8Content;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,10 +45,14 @@ public class LogbookConfiguration {
 	private final Set<String> excludedPaths;
 
 	LogbookConfiguration(
-		@Value("#{'${logbook.logger.name:${logbook.default.logger.name:}}'}") String loggerName,
-		@Value("#{'${logbook.excluded.paths:${logbook.default.excluded.paths:}}'}") Set<String> excludedPaths) {
+			@Value("#{'${logbook.logger.name:${logbook.default.logger.name:}}'}") String loggerName,
+			@Value("${logbook.default.excluded.paths}") Set<String> defaultExcludedPaths,
+			@Value("${logbook.excluded.paths:}") Set<String> additionalExcludedPaths) {
 		this.loggerName = loggerName;
-		this.excludedPaths = excludedPaths;
+
+		excludedPaths = Stream.of(defaultExcludedPaths, additionalExcludedPaths)
+			.flatMap(Collection::stream)
+			.collect(Collectors.toSet());
 	}
 
 	@Bean


### PR DESCRIPTION
Merges `logbook.default.excluded.paths` and `logbook.excluded.paths` instead of the latter overwriting the former, if set.

Also, makes the `logbook.default.excluded.paths` property mandatory, since this change would most likely render the case of ever having/wanting to use something other than the default provided by the framework irrelevant.

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Code style update (formatting etc.)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [ ] I have added/updated tests to cover my changes (if applicable).
