### PR TITLE
UF-6951: Update Exclusionfilters for logbook

### DIFF
--- a/dept44-build-tools/pom.xml
+++ b/dept44-build-tools/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>se.sundsvall.dept44</groupId>
 		<artifactId>dept44-parent</artifactId>
-		<version>4.2.1-SNAPSHOT</version>
+		<version>4.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>dept44-build-tools</artifactId>
 	<packaging>maven-plugin</packaging>

--- a/dept44-common-validators/pom.xml
+++ b/dept44-common-validators/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>se.sundsvall.dept44</groupId>
 		<artifactId>dept44-parent</artifactId>
-		<version>4.2.1-SNAPSHOT</version>
+		<version>4.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>dept44-common-validators</artifactId>
 

--- a/dept44-example/pom.xml
+++ b/dept44-example/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>se.sundsvall.dept44</groupId>
 		<artifactId>dept44-service-parent</artifactId>
-		<version>4.2.1-SNAPSHOT</version>
+		<version>4.3.0-SNAPSHOT</version>
 		<relativePath>../dept44-service-parent</relativePath>
 	</parent>
 	<groupId>se.sundsvall</groupId>

--- a/dept44-models/pom.xml
+++ b/dept44-models/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>se.sundsvall.dept44</groupId>
         <artifactId>dept44-parent</artifactId>
-        <version>4.2.1-SNAPSHOT</version>
+        <version>4.3.0-SNAPSHOT</version>
     </parent>
     <artifactId>dept44-models</artifactId>
 

--- a/dept44-service-parent/pom.xml
+++ b/dept44-service-parent/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>se.sundsvall.dept44</groupId>
 		<artifactId>dept44-parent</artifactId>
-		<version>4.2.1-SNAPSHOT</version>
+		<version>4.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>dept44-service-parent</artifactId>
 	<packaging>pom</packaging>

--- a/dept44-starter-authorization/pom.xml
+++ b/dept44-starter-authorization/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>se.sundsvall.dept44</groupId>
 		<artifactId>dept44-starter-parent</artifactId>
-		<version>4.2.1-SNAPSHOT</version>
+		<version>4.3.0-SNAPSHOT</version>
 		<relativePath>../dept44-starter-parent</relativePath>
 	</parent>
 	<artifactId>dept44-starter-authorization</artifactId>

--- a/dept44-starter-feign/pom.xml
+++ b/dept44-starter-feign/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>se.sundsvall.dept44</groupId>
 		<artifactId>dept44-starter-parent</artifactId>
-		<version>4.2.1-SNAPSHOT</version>
+		<version>4.3.0-SNAPSHOT</version>
 		<relativePath>../dept44-starter-parent</relativePath>
 	</parent>
 	<artifactId>dept44-starter-feign</artifactId>

--- a/dept44-starter-logback-logserver/pom.xml
+++ b/dept44-starter-logback-logserver/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>se.sundsvall.dept44</groupId>
 		<artifactId>dept44-starter-parent</artifactId>
-		<version>4.2.1-SNAPSHOT</version>
+		<version>4.3.0-SNAPSHOT</version>
 		<relativePath>../dept44-starter-parent</relativePath>
 	</parent>
 	<artifactId>dept44-starter-logback-logserver</artifactId>

--- a/dept44-starter-parent/pom.xml
+++ b/dept44-starter-parent/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>se.sundsvall.dept44</groupId>
 		<artifactId>dept44-parent</artifactId>
-		<version>4.2.1-SNAPSHOT</version>
+		<version>4.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>dept44-starter-parent</artifactId>
 	<packaging>pom</packaging>

--- a/dept44-starter-test/pom.xml
+++ b/dept44-starter-test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>se.sundsvall.dept44</groupId>
 		<artifactId>dept44-starter-parent</artifactId>
-		<version>4.2.1-SNAPSHOT</version>
+		<version>4.3.0-SNAPSHOT</version>
 		<relativePath>../dept44-starter-parent</relativePath>
 	</parent>
 	<artifactId>dept44-starter-test</artifactId>

--- a/dept44-starter-webclient/pom.xml
+++ b/dept44-starter-webclient/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>se.sundsvall.dept44</groupId>
 		<artifactId>dept44-starter-parent</artifactId>
-		<version>4.2.1-SNAPSHOT</version>
+		<version>4.3.0-SNAPSHOT</version>
 		<relativePath>../dept44-starter-parent</relativePath>
 	</parent>
 	<artifactId>dept44-starter-webclient</artifactId>

--- a/dept44-starter-webservicetemplate/pom.xml
+++ b/dept44-starter-webservicetemplate/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>se.sundsvall.dept44</groupId>
 		<artifactId>dept44-starter-parent</artifactId>
-		<version>4.2.1-SNAPSHOT</version>
+		<version>4.3.0-SNAPSHOT</version>
 		<relativePath>../dept44-starter-parent</relativePath>
 	</parent>
 	<artifactId>dept44-starter-webservicetemplate</artifactId>

--- a/dept44-starter/pom.xml
+++ b/dept44-starter/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>se.sundsvall.dept44</groupId>
 		<artifactId>dept44-starter-parent</artifactId>
-		<version>4.2.1-SNAPSHOT</version>
+		<version>4.3.0-SNAPSHOT</version>
 		<relativePath>../dept44-starter-parent</relativePath>
 	</parent>
 	<artifactId>dept44-starter</artifactId>

--- a/dept44-starter/src/main/java/se/sundsvall/dept44/configuration/BodyFilterProperties.java
+++ b/dept44-starter/src/main/java/se/sundsvall/dept44/configuration/BodyFilterProperties.java
@@ -1,0 +1,33 @@
+package se.sundsvall.dept44.configuration;
+
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "logbook.body-filters")
+@ConditionalOnMissingBean(BodyFilterProperties.class)
+public class BodyFilterProperties {
+
+	private List<Map<String, String>> jsonPath;
+	private List<Map<String, String>> xPath;
+
+	public List<Map<String, String>> getJsonPath() {
+		return jsonPath;
+	}
+
+	public void setJsonPath(final List<Map<String, String>> jsonPath) {
+		this.jsonPath = jsonPath;
+	}
+
+	public List<Map<String, String>> getxPath() {
+		return xPath;
+	}
+
+	public void setxPath(final List<Map<String, String>> xPath) {
+		this.xPath = xPath;
+	}
+
+}

--- a/dept44-starter/src/main/java/se/sundsvall/dept44/configuration/ExclusionFilterProperties.java
+++ b/dept44-starter/src/main/java/se/sundsvall/dept44/configuration/ExclusionFilterProperties.java
@@ -5,8 +5,12 @@ import java.util.Map;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+/**
+ * @deprecated Since 4.3.0. Use {@link BodyFilterProperties} instead. Subject for removal in 5.0.0
+ */
 @ConfigurationProperties(prefix = "logbook.exclusionfilters")
 @ConditionalOnMissingBean(ExclusionFilterProperties.class)
+@Deprecated(since = "4.3.0", forRemoval = true)
 public class ExclusionFilterProperties {
 	private Map<String, String> jsonPath;
 	private Map<String, String> xPath;

--- a/dept44-starter/src/test/java/se/sundsvall/dept44/configuration/BodyFilterPropertiesTest.java
+++ b/dept44-starter/src/test/java/se/sundsvall/dept44/configuration/BodyFilterPropertiesTest.java
@@ -1,0 +1,39 @@
+package se.sundsvall.dept44.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(classes = { LogbookConfiguration.class, BodyFilterProperties.class, ObjectMapperConfiguration.class })
+@ActiveProfiles("junit")
+class BodyFilterPropertiesTest {
+
+	@Autowired
+	BodyFilterProperties properties;
+
+
+	@Test
+	void testProperties(){
+
+		assertThat(properties.getJsonPath()).hasSize(2);
+		assertThat(properties.getxPath()).hasSize(2);
+
+		assertThat(properties.getJsonPath().getFirst().entrySet()).containsExactly(
+			Map.entry("key", "some_yml_jsonpath_key_1"),
+			Map.entry("value", "some_yml_jsonpath_value_1")
+		);
+		assertThat(properties.getJsonPath().get(1).entrySet()).containsExactly(
+			Map.entry("key", "some_yml_jsonpath_key_2"),
+			Map.entry("value", "some_yml_jsonpath_value_2"));
+		assertThat(properties.getxPath().getFirst().entrySet()).containsExactly(
+			Map.entry("key", "some_yml_xpath_key_1"),
+			Map.entry("value", "some_yml_xpath_value_1"));
+	}
+}

--- a/dept44-starter/src/test/java/se/sundsvall/dept44/configuration/LogbookConfigurationTest.java
+++ b/dept44-starter/src/test/java/se/sundsvall/dept44/configuration/LogbookConfigurationTest.java
@@ -7,7 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.zalando.logbook.Logbook;
 
-@SpringBootTest(classes = { LogbookConfiguration.class, ExclusionFilterProperties.class, ObjectMapperConfiguration.class })
+@SpringBootTest(classes = { LogbookConfiguration.class, ExclusionFilterProperties.class, ObjectMapperConfiguration.class, BodyFilterProperties.class})
 class LogbookConfigurationTest {
 
 	@Autowired

--- a/dept44-starter/src/test/resources/application-junit.yaml
+++ b/dept44-starter/src/test/resources/application-junit.yaml
@@ -6,3 +6,14 @@ logbook:
     xPath:
       yml_path_1: xpath_yml_replacement_1
       yml_path_2: xpath_yml_replacement_2
+  body-filters:
+    jsonPath:
+      - key: 'some_yml_jsonpath_key_1'
+        value: 'some_yml_jsonpath_value_1'
+      - key: 'some_yml_jsonpath_key_2'
+        value: 'some_yml_jsonpath_value_2'
+    xPath:
+      - key: 'some_yml_xpath_key_1'
+        value: 'some_yml_xpath_value_1'
+      - key: 'some_yml_xpath_key_2'
+        value: 'some_yml_xpath_value_2'

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>se.sundsvall.dept44</groupId>
 	<artifactId>dept44-parent</artifactId>
-	<version>4.2.1-SNAPSHOT</version>
+	<version>4.3.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>dept44-parent</name>
 	<description>Sundsvalls kommun spring boot library</description>
@@ -163,47 +163,47 @@
 			<dependency>
 				<groupId>se.sundsvall.dept44</groupId>
 				<artifactId>dept44-starter</artifactId>
-				<version>4.2.1-SNAPSHOT</version>
+				<version>4.3.0-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>se.sundsvall.dept44</groupId>
 				<artifactId>dept44-starter-authorization</artifactId>
-				<version>4.2.1-SNAPSHOT</version>
+				<version>4.3.0-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>se.sundsvall.dept44</groupId>
 				<artifactId>dept44-common-validators</artifactId>
-				<version>4.2.1-SNAPSHOT</version>
+				<version>4.3.0-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>se.sundsvall.dept44</groupId>
 				<artifactId>dept44-models</artifactId>
-				<version>4.2.1-SNAPSHOT</version>
+				<version>4.3.0-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>se.sundsvall.dept44</groupId>
 				<artifactId>dept44-starter-feign</artifactId>
-				<version>4.2.1-SNAPSHOT</version>
+				<version>4.3.0-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>se.sundsvall.dept44</groupId>
 				<artifactId>dept44-starter-logback-logserver</artifactId>
-				<version>4.2.1-SNAPSHOT</version>
+				<version>4.3.0-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>se.sundsvall.dept44</groupId>
 				<artifactId>dept44-starter-test</artifactId>
-				<version>4.2.1-SNAPSHOT</version>
+				<version>4.3.0-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>se.sundsvall.dept44</groupId>
 				<artifactId>dept44-starter-webclient</artifactId>
-				<version>4.2.1-SNAPSHOT</version>
+				<version>4.3.0-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>se.sundsvall.dept44</groupId>
 				<artifactId>dept44-starter-webservicetemplate</artifactId>
-				<version>4.2.1-SNAPSHOT</version>
+				<version>4.3.0-SNAPSHOT</version>
 			</dependency>
 			<!-- Problem -->
 			<dependency>
@@ -272,7 +272,7 @@
 				<plugin>
 					<groupId>se.sundsvall.dept44</groupId>
 					<artifactId>dept44-build-tools</artifactId>
-					<version>4.2.1-SNAPSHOT</version>
+					<version>4.3.0-SNAPSHOT</version>
 					<executions>
 						<execution>
 							<phase>initialize</phase>


### PR DESCRIPTION
New way to configure exclusionsfilters or rather bodyfilters implemented. Instead of doing the old way:
```
    xPath:
      '*//[contains(@name, ".pdf")]': '[base64]'
```
the new way will be to use the following syntax
```
	xPath:
	   - key: '//*[contains(@name, ".pdf")]' 
	     value: '[base64]'
```

	  
The old way to configure exclusionsfilters are marked for removal in the next major.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix
- [x] New feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
