### PR TITLE
UF-7921 - AbstractAppTest - service path using UriBuilder

### DIFF
--- a/dept44-starter-test/src/test/java/se/sundsvall/dept44/test/AbstractAppTestTest.java
+++ b/dept44-starter-test/src/test/java/se/sundsvall/dept44/test/AbstractAppTestTest.java
@@ -88,13 +88,16 @@ class AbstractAppTestTest {
 		when(wiremockMock.getOptions()).thenReturn(optionsMock).thenReturn(wireMockConfigMock); // The second invocation is a cast, hence this.
 		when(optionsMock.filesRoot()).thenReturn(fileSourceMock);
 		when(fileSourceMock.getPath()).thenReturn("/filepath");
-		when(restTemplateMock.exchange(eq("/some/path"), eq(GET), any(), eq(String.class))).thenReturn(new ResponseEntity<>("{}", responseHeaders, OK));
+		when(restTemplateMock.exchange(eq("/some/path/123?someParam=someValue"), eq(GET), any(), eq(String.class))).thenReturn(new ResponseEntity<>("{}", responseHeaders, OK));
 		when(wiremockMock.listAllStubMappings()).thenReturn(new ListStubMappingsResult(List.of(new StubMapping()), null));
 
 		// Call
 		final var instance = appTest.setupCall()
 			.withExtensions(extensionMock)
-			.withServicePath("/some/path")
+			.withServicePath(uriBuilder -> uriBuilder.path("/some/path/{value}")
+				.queryParam("someParam", "someValue")
+				.build(123))
+			//.withServicePath("/some/path")
 			.withHttpMethod(GET)
 			.withHeader("headerKey", "headerValue")
 			.withExpectedResponse("{}")
@@ -106,7 +109,7 @@ class AbstractAppTestTest {
 
 		// Verification
 		assertThat(instance).isNotNull();
-		verify(restTemplateMock).exchange(eq("/some/path"), eq(GET), httpEntityCaptor.capture(), eq(String.class));
+		verify(restTemplateMock).exchange(eq("/some/path/123?someParam=someValue"), eq(GET), httpEntityCaptor.capture(), eq(String.class));
 		verify(wiremockMock, times(2)).loadMappingsUsing(any(JsonFileMappingsSource.class));
 		verify(wiremockMock).findAllUnmatchedRequests();
 		verify(wiremockMock).verify(any());

--- a/dept44-starter/src/main/java/se/sundsvall/dept44/configuration/WebFluxConfiguration.java
+++ b/dept44-starter/src/main/java/se/sundsvall/dept44/configuration/WebFluxConfiguration.java
@@ -3,7 +3,6 @@ package se.sundsvall.dept44.configuration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.CacheControl;
 import org.springframework.web.reactive.config.EnableWebFlux;
 import org.springframework.web.reactive.config.WebFluxConfigurer;
 import org.springframework.web.server.ServerWebExchange;

--- a/dept44-starter/src/test/java/se/sundsvall/dept44/configuration/WebFluxConfigurationTest.java
+++ b/dept44-starter/src/test/java/se/sundsvall/dept44/configuration/WebFluxConfigurationTest.java
@@ -10,12 +10,9 @@ import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.CacheControl;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpResponse;


### PR DESCRIPTION
Adds an overload of the `AbstractAppTest#withServicePath` method to be able to use a `UriBuilder` a la `WebTestClient`. May be useful when constructing complex paths. (The "old" way is still ofc still available).

Example:
```
setupCall()
    .withServicePath(uriBuilder -> uriBuilder.path("/some/path/{value}")
        .queryParam("someParam", "someValue")
        ...
        .build(Map.of("value", 12345))
    ...
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix
- [x] New feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
