### PR TITLE
UF-9779 - Reintroduce Spring Cloud config deps

### DIFF
--- a/dept44-example/src/integration-test/resources/EndpointsIT/__files/test02_health/response.json
+++ b/dept44-example/src/integration-test/resources/EndpointsIT/__files/test02_health/response.json
@@ -21,6 +21,12 @@
 				}
 			}
 		},
+		"clientConfigServer": {
+			"status": "UNKNOWN",
+			"details": {
+				"error": "no property sources located"
+			}
+		},
 		"db": {
 			"status": "UP",
 			"details": {

--- a/dept44-starter/pom.xml
+++ b/dept44-starter/pom.xml
@@ -38,10 +38,6 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-kubernetes-client-config</artifactId>
-		</dependency>
 		<!-- Jackson -->
 		<dependency>
 			<groupId>com.fasterxml.jackson.module</groupId>
@@ -89,6 +85,19 @@
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+		</dependency>
+		<!-- Cloud config -->
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-kubernetes-client-config</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-config</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-bootstrap</artifactId>
 		</dependency>
 		<!-- Resilience4j Circuitbreaker (health-indicators) -->
 		<dependency>


### PR DESCRIPTION
Reintroduces Spring Cloud config dependencies, as services don't seem to be able to read/handle config maps anymore

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## Does this PR introduce a breaking change?
- [x] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
