### PR TITLE
UF-10753: Dept44-formatting-plugin handles imports

### DIFF
--- a/dept44-build-tools/src/main/java/se/sundsvall/dept44/maven/mojo/AbstractDept44CheckMojo.java
+++ b/dept44-build-tools/src/main/java/se/sundsvall/dept44/maven/mojo/AbstractDept44CheckMojo.java
@@ -5,7 +5,6 @@ import static java.util.stream.Collectors.joining;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Parameter;

--- a/dept44-build-tools/src/main/java/se/sundsvall/dept44/maven/mojo/CheckOpenApiPropertiesMojo.java
+++ b/dept44-build-tools/src/main/java/se/sundsvall/dept44/maven/mojo/CheckOpenApiPropertiesMojo.java
@@ -3,6 +3,10 @@ package se.sundsvall.dept44.maven.mojo;
 import static java.util.Optional.ofNullable;
 import static org.apache.commons.lang3.ArrayUtils.isEmpty;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -10,16 +14,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
-
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 @Mojo(name = "check-openapi-properties", defaultPhase = LifecyclePhase.INITIALIZE)
 public class CheckOpenApiPropertiesMojo extends AbstractDept44CheckMojo {

--- a/dept44-build-tools/src/main/java/se/sundsvall/dept44/maven/mojo/CheckTruststoreValidityMojo.java
+++ b/dept44-build-tools/src/main/java/se/sundsvall/dept44/maven/mojo/CheckTruststoreValidityMojo.java
@@ -10,7 +10,6 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.time.LocalDate;
 import java.time.ZoneId;
-
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;

--- a/dept44-build-tools/src/test/java/se/sundsvall/dept44/maven/mojo/CheckOpenApiPropertiesMojoTest.java
+++ b/dept44-build-tools/src/test/java/se/sundsvall/dept44/maven/mojo/CheckOpenApiPropertiesMojoTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
-
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.project.MavenProject;
 import org.junit.jupiter.api.BeforeEach;

--- a/dept44-build-tools/src/test/java/se/sundsvall/dept44/maven/mojo/CheckTruststoreValidityMojoTest.java
+++ b/dept44-build-tools/src/test/java/se/sundsvall/dept44/maven/mojo/CheckTruststoreValidityMojoTest.java
@@ -15,7 +15,6 @@ import java.security.SecureRandom;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Date;
-
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.project.MavenProject;
 import org.bouncycastle.asn1.ASN1InputStream;

--- a/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/MemberOf.java
+++ b/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/MemberOf.java
@@ -1,14 +1,12 @@
 package se.sundsvall.dept44.common.validators.annotation;
 
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
-import jakarta.validation.Constraint;
-import jakarta.validation.Payload;
-
 import se.sundsvall.dept44.common.validators.annotation.impl.MemberOfConstraintValidator;
 
 /**

--- a/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/OneOf.java
+++ b/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/OneOf.java
@@ -1,13 +1,12 @@
 package se.sundsvall.dept44.common.validators.annotation;
 
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
-import jakarta.validation.Constraint;
-import jakarta.validation.Payload;
 import se.sundsvall.dept44.common.validators.annotation.impl.OneOfConstraintValidator;
 
 /**

--- a/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/ValidBase64.java
+++ b/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/ValidBase64.java
@@ -1,14 +1,12 @@
 package se.sundsvall.dept44.common.validators.annotation;
 
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
-import jakarta.validation.Constraint;
-import jakarta.validation.Payload;
-
 import se.sundsvall.dept44.common.validators.annotation.impl.ValidBase64ConstraintValidator;
 
 /**

--- a/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/ValidMSISDN.java
+++ b/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/ValidMSISDN.java
@@ -1,13 +1,12 @@
 package se.sundsvall.dept44.common.validators.annotation;
 
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
-import jakarta.validation.Constraint;
-import jakarta.validation.Payload;
 import se.sundsvall.dept44.common.validators.annotation.impl.ValidMSISDNConstraintValidator;
 
 /**

--- a/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/ValidMobileNumber.java
+++ b/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/ValidMobileNumber.java
@@ -1,14 +1,12 @@
 package se.sundsvall.dept44.common.validators.annotation;
 
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
-import jakarta.validation.Constraint;
-import jakarta.validation.Payload;
-
 import se.sundsvall.dept44.common.validators.annotation.impl.ValidMobileNumberConstraintValidator;
 
 /**

--- a/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/ValidMunicipalityId.java
+++ b/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/ValidMunicipalityId.java
@@ -1,14 +1,12 @@
 package se.sundsvall.dept44.common.validators.annotation;
 
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
-import jakarta.validation.Constraint;
-import jakarta.validation.Payload;
-
 import se.sundsvall.dept44.common.validators.annotation.impl.ValidMunicipalityIdConstraintValidator;
 
 /**

--- a/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/ValidOrganizationNumber.java
+++ b/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/ValidOrganizationNumber.java
@@ -1,14 +1,12 @@
 package se.sundsvall.dept44.common.validators.annotation;
 
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
-import jakarta.validation.Constraint;
-import jakarta.validation.Payload;
-
 import se.sundsvall.dept44.common.validators.annotation.impl.ValidOrganizationNumberConstraintValidator;
 
 /**

--- a/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/ValidPersonalNumber.java
+++ b/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/ValidPersonalNumber.java
@@ -1,14 +1,12 @@
 package se.sundsvall.dept44.common.validators.annotation;
 
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
-import jakarta.validation.Constraint;
-import jakarta.validation.Payload;
-
 import se.sundsvall.dept44.common.validators.annotation.impl.ValidPersonalNumberConstraintValidator;
 
 /**

--- a/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/ValidUuid.java
+++ b/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/ValidUuid.java
@@ -1,14 +1,12 @@
 package se.sundsvall.dept44.common.validators.annotation;
 
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
-import jakarta.validation.Constraint;
-import jakarta.validation.Payload;
-
 import se.sundsvall.dept44.common.validators.annotation.impl.ValidUuidConstraintValidator;
 
 /**

--- a/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/impl/AbstractValidator.java
+++ b/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/impl/AbstractValidator.java
@@ -2,9 +2,8 @@ package se.sundsvall.dept44.common.validators.annotation.impl;
 
 import static se.sundsvall.dept44.util.ResourceUtils.requireNonNull;
 
-import java.util.function.Supplier;
-
 import jakarta.validation.constraints.NotNull;
+import java.util.function.Supplier;
 import se.sundsvall.dept44.common.validators.annotation.exception.IncompatibleAnnotationException;
 
 abstract class AbstractValidator {

--- a/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/impl/MemberOfConstraintValidator.java
+++ b/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/impl/MemberOfConstraintValidator.java
@@ -6,18 +6,15 @@ import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toCollection;
 import static org.springframework.util.ReflectionUtils.findMethod;
 
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Supplier;
-
-import jakarta.validation.ConstraintValidator;
-import jakarta.validation.ConstraintValidatorContext;
-
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
-
 import se.sundsvall.dept44.common.validators.annotation.MemberOf;
 import se.sundsvall.dept44.common.validators.annotation.OneOf;
 

--- a/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/impl/OneOfConstraintValidator.java
+++ b/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/impl/OneOfConstraintValidator.java
@@ -4,15 +4,12 @@ import static java.util.Objects.isNull;
 import static java.util.Optional.ofNullable;
 import static org.springframework.util.ReflectionUtils.findMethod;
 
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
-
-import jakarta.validation.ConstraintValidator;
-import jakarta.validation.ConstraintValidatorContext;
-
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorContextImpl;
-
 import se.sundsvall.dept44.common.validators.annotation.OneOf;
 
 /**

--- a/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidBase64ConstraintValidator.java
+++ b/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidBase64ConstraintValidator.java
@@ -5,12 +5,10 @@ import static java.util.Optional.ofNullable;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.springframework.util.ReflectionUtils.findMethod;
 
-import java.lang.reflect.Method;
-import java.util.Base64;
-
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
-
+import java.lang.reflect.Method;
+import java.util.Base64;
 import se.sundsvall.dept44.common.validators.annotation.ValidBase64;
 
 /**

--- a/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidMSISDNConstraintValidator.java
+++ b/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidMSISDNConstraintValidator.java
@@ -5,10 +5,9 @@ import static java.util.Objects.nonNull;
 import static java.util.Optional.ofNullable;
 import static org.springframework.util.ReflectionUtils.findMethod;
 
-import java.lang.reflect.Method;
-
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
+import java.lang.reflect.Method;
 import se.sundsvall.dept44.common.validators.annotation.ValidMSISDN;
 
 /**

--- a/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidMobileNumberConstraintValidator.java
+++ b/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidMobileNumberConstraintValidator.java
@@ -5,11 +5,9 @@ import static java.util.Objects.nonNull;
 import static java.util.Optional.ofNullable;
 import static org.springframework.util.ReflectionUtils.findMethod;
 
-import java.lang.reflect.Method;
-
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
-
+import java.lang.reflect.Method;
 import se.sundsvall.dept44.common.validators.annotation.ValidMobileNumber;
 
 /**

--- a/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidMunicipalityIdConstraintValidator.java
+++ b/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidMunicipalityIdConstraintValidator.java
@@ -5,11 +5,9 @@ import static java.util.Objects.nonNull;
 import static java.util.Optional.ofNullable;
 import static org.springframework.util.ReflectionUtils.findMethod;
 
-import java.lang.reflect.Method;
-
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
-
+import java.lang.reflect.Method;
 import se.sundsvall.dept44.common.validators.annotation.ValidMunicipalityId;
 import se.sundsvall.dept44.util.MunicipalityUtils;
 

--- a/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidOrganizationNumberConstraintValidator.java
+++ b/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidOrganizationNumberConstraintValidator.java
@@ -5,11 +5,9 @@ import static java.util.Objects.nonNull;
 import static java.util.Optional.ofNullable;
 import static org.springframework.util.ReflectionUtils.findMethod;
 
-import java.lang.reflect.Method;
-
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
-
+import java.lang.reflect.Method;
 import se.sundsvall.dept44.common.validators.annotation.ValidOrganizationNumber;
 
 /**

--- a/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidPersonalNumberConstraintValidator.java
+++ b/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidPersonalNumberConstraintValidator.java
@@ -5,11 +5,9 @@ import static java.util.Objects.nonNull;
 import static java.util.Optional.ofNullable;
 import static org.springframework.util.ReflectionUtils.findMethod;
 
-import java.lang.reflect.Method;
-
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
-
+import java.lang.reflect.Method;
 import se.sundsvall.dept44.common.validators.annotation.ValidPersonalNumber;
 
 /**

--- a/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidUuidConstraintValidator.java
+++ b/dept44-common-validators/src/main/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidUuidConstraintValidator.java
@@ -4,12 +4,10 @@ import static java.util.Objects.isNull;
 import static java.util.Optional.ofNullable;
 import static org.springframework.util.ReflectionUtils.findMethod;
 
-import java.lang.reflect.Method;
-import java.util.UUID;
-
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
-
+import java.lang.reflect.Method;
+import java.util.UUID;
 import se.sundsvall.dept44.common.validators.annotation.ValidUuid;
 
 /**

--- a/dept44-common-validators/src/test/java/se/sundsvall/dept44/common/validators/annotation/impl/MemberOfConstraintValidatorTest.java
+++ b/dept44-common-validators/src/test/java/se/sundsvall/dept44/common/validators/annotation/impl/MemberOfConstraintValidatorTest.java
@@ -2,14 +2,12 @@ package se.sundsvall.dept44.common.validators.annotation.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
-
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -19,7 +17,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import se.sundsvall.dept44.common.validators.annotation.MemberOf;
 
 @ExtendWith(MockitoExtension.class)

--- a/dept44-common-validators/src/test/java/se/sundsvall/dept44/common/validators/annotation/impl/OneOfConstraintValidatorTest.java
+++ b/dept44-common-validators/src/test/java/se/sundsvall/dept44/common/validators/annotation/impl/OneOfConstraintValidatorTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
-
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorContextImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -15,7 +14,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import se.sundsvall.dept44.common.validators.annotation.OneOf;
 
 @ExtendWith(MockitoExtension.class)

--- a/dept44-common-validators/src/test/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidBase64ConstraintValidatorTest.java
+++ b/dept44-common-validators/src/test/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidBase64ConstraintValidatorTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import se.sundsvall.dept44.common.validators.annotation.ValidBase64;
 
 @ExtendWith(MockitoExtension.class)

--- a/dept44-common-validators/src/test/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidMSISDNConstraintValidatorTest.java
+++ b/dept44-common-validators/src/test/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidMSISDNConstraintValidatorTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import se.sundsvall.dept44.common.validators.annotation.ValidMSISDN;
 
 @ExtendWith(MockitoExtension.class)

--- a/dept44-common-validators/src/test/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidMobileNumberConstraintValidatorTest.java
+++ b/dept44-common-validators/src/test/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidMobileNumberConstraintValidatorTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import se.sundsvall.dept44.common.validators.annotation.ValidMobileNumber;
 
 @ExtendWith(MockitoExtension.class)

--- a/dept44-common-validators/src/test/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidMunicipalityIdConstraintValidatorTest.java
+++ b/dept44-common-validators/src/test/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidMunicipalityIdConstraintValidatorTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import se.sundsvall.dept44.common.validators.annotation.ValidMunicipalityId;
 
 @ExtendWith(MockitoExtension.class)

--- a/dept44-common-validators/src/test/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidOrganizationNumberConstraintValidatorTest.java
+++ b/dept44-common-validators/src/test/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidOrganizationNumberConstraintValidatorTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import se.sundsvall.dept44.common.validators.annotation.ValidOrganizationNumber;
 
 @ExtendWith(MockitoExtension.class)

--- a/dept44-common-validators/src/test/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidPersonalNumberConstraintValidatorTest.java
+++ b/dept44-common-validators/src/test/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidPersonalNumberConstraintValidatorTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import se.sundsvall.dept44.common.validators.annotation.ValidPersonalNumber;
 
 @ExtendWith(MockitoExtension.class)

--- a/dept44-common-validators/src/test/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidUuidConstraintValidatorTest.java
+++ b/dept44-common-validators/src/test/java/se/sundsvall/dept44/common/validators/annotation/impl/ValidUuidConstraintValidatorTest.java
@@ -6,13 +6,11 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.UUID;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import se.sundsvall.dept44.common.validators.annotation.ValidUuid;
 
 @ExtendWith(MockitoExtension.class)

--- a/dept44-example/src/main/java/se/sundsvall/petinventory/Application.java
+++ b/dept44-example/src/main/java/se/sundsvall/petinventory/Application.java
@@ -3,7 +3,6 @@ package se.sundsvall.petinventory;
 import static org.springframework.boot.SpringApplication.run;
 
 import org.springframework.cloud.openfeign.EnableFeignClients;
-
 import se.sundsvall.dept44.ServiceApplication;
 import se.sundsvall.dept44.util.jacoco.ExcludeFromJacocoGeneratedCoverageReport;
 

--- a/dept44-example/src/main/java/se/sundsvall/petinventory/api/PetInventoryResource.java
+++ b/dept44-example/src/main/java/se/sundsvall/petinventory/api/PetInventoryResource.java
@@ -10,8 +10,12 @@ import static org.springframework.http.ResponseEntity.created;
 import static org.springframework.http.ResponseEntity.ok;
 import static org.springframework.web.util.UriComponentsBuilder.fromPath;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
-
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -24,12 +28,6 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import org.zalando.problem.Problem;
 import org.zalando.problem.violations.ConstraintViolationProblem;
-
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import se.sundsvall.petinventory.api.model.PetInventoryItem;
 import se.sundsvall.petinventory.service.PetInventoryService;
 

--- a/dept44-example/src/main/java/se/sundsvall/petinventory/api/model/PetImage.java
+++ b/dept44-example/src/main/java/se/sundsvall/petinventory/api/model/PetImage.java
@@ -1,8 +1,7 @@
 package se.sundsvall.petinventory.api.model;
 
-import java.util.Objects;
-
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Objects;
 
 @Schema(description = "Pet image model")
 public class PetImage {

--- a/dept44-example/src/main/java/se/sundsvall/petinventory/api/model/PetInventoryItem.java
+++ b/dept44-example/src/main/java/se/sundsvall/petinventory/api/model/PetInventoryItem.java
@@ -1,10 +1,9 @@
 package se.sundsvall.petinventory.api.model;
 
-import java.util.List;
-import java.util.Objects;
-
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.Objects;
 
 @Schema(description = "Pet inventory item model")
 public class PetInventoryItem {

--- a/dept44-example/src/main/java/se/sundsvall/petinventory/integration/db/PetImageRepository.java
+++ b/dept44-example/src/main/java/se/sundsvall/petinventory/integration/db/PetImageRepository.java
@@ -1,12 +1,10 @@
 package se.sundsvall.petinventory.integration.db;
 
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import java.util.List;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.transaction.annotation.Transactional;
-
-import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import se.sundsvall.petinventory.integration.db.model.PetImageEntity;
 
 @Transactional

--- a/dept44-example/src/main/java/se/sundsvall/petinventory/integration/db/PetNameRepository.java
+++ b/dept44-example/src/main/java/se/sundsvall/petinventory/integration/db/PetNameRepository.java
@@ -1,12 +1,10 @@
 package se.sundsvall.petinventory.integration.db;
 
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import java.util.Optional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.transaction.annotation.Transactional;
-
-import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import se.sundsvall.petinventory.integration.db.model.PetNameEntity;
 
 @Transactional

--- a/dept44-example/src/main/java/se/sundsvall/petinventory/integration/db/model/PetImageEntity.java
+++ b/dept44-example/src/main/java/se/sundsvall/petinventory/integration/db/model/PetImageEntity.java
@@ -2,13 +2,6 @@ package se.sundsvall.petinventory.integration.db.model;
 
 import static org.hibernate.Length.LONG32;
 
-import java.time.OffsetDateTime;
-import java.util.Arrays;
-import java.util.Objects;
-
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -20,6 +13,11 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.Objects;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import se.sundsvall.petinventory.integration.db.model.listener.PetImageEntityListener;
 
 @Entity

--- a/dept44-example/src/main/java/se/sundsvall/petinventory/integration/db/model/PetNameEntity.java
+++ b/dept44-example/src/main/java/se/sundsvall/petinventory/integration/db/model/PetNameEntity.java
@@ -1,9 +1,5 @@
 package se.sundsvall.petinventory.integration.db.model;
 
-import java.time.OffsetDateTime;
-import java.util.List;
-import java.util.Objects;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -14,6 +10,9 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Objects;
 import se.sundsvall.petinventory.integration.db.model.listener.PetNameEntityListener;
 
 @Entity

--- a/dept44-example/src/main/java/se/sundsvall/petinventory/integration/db/model/listener/PetImageEntityListener.java
+++ b/dept44-example/src/main/java/se/sundsvall/petinventory/integration/db/model/listener/PetImageEntityListener.java
@@ -3,10 +3,9 @@ package se.sundsvall.petinventory.integration.db.model.listener;
 import static java.time.OffsetDateTime.now;
 import static java.time.temporal.ChronoUnit.MILLIS;
 
-import java.time.ZoneId;
-
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
+import java.time.ZoneId;
 import se.sundsvall.petinventory.integration.db.model.PetImageEntity;
 
 public class PetImageEntityListener {

--- a/dept44-example/src/main/java/se/sundsvall/petinventory/integration/db/model/listener/PetNameEntityListener.java
+++ b/dept44-example/src/main/java/se/sundsvall/petinventory/integration/db/model/listener/PetNameEntityListener.java
@@ -3,11 +3,9 @@ package se.sundsvall.petinventory.integration.db.model.listener;
 import static java.time.OffsetDateTime.now;
 import static java.time.temporal.ChronoUnit.MILLIS;
 
-import java.time.ZoneId;
-
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
-
+import java.time.ZoneId;
 import se.sundsvall.petinventory.integration.db.model.PetNameEntity;
 
 public class PetNameEntityListener {

--- a/dept44-example/src/main/java/se/sundsvall/petinventory/integration/petstore/PetStoreClient.java
+++ b/dept44-example/src/main/java/se/sundsvall/petinventory/integration/petstore/PetStoreClient.java
@@ -1,16 +1,15 @@
 package se.sundsvall.petinventory.integration.petstore;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static se.sundsvall.petinventory.integration.petstore.configuration.PetStoreConfiguration.CLIENT_ID;
+
 import generated.swagger.io.petstore.Pet;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import se.sundsvall.petinventory.integration.petstore.configuration.PetStoreConfiguration;
-
-import java.util.List;
-import java.util.Optional;
-
-import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
-import static se.sundsvall.petinventory.integration.petstore.configuration.PetStoreConfiguration.CLIENT_ID;
 
 @FeignClient(name = CLIENT_ID, url = "${integration.petstore.url}", configuration = PetStoreConfiguration.class)
 public interface PetStoreClient {

--- a/dept44-example/src/main/java/se/sundsvall/petinventory/integration/petstore/configuration/PetStoreConfiguration.java
+++ b/dept44-example/src/main/java/se/sundsvall/petinventory/integration/petstore/configuration/PetStoreConfiguration.java
@@ -3,12 +3,10 @@ package se.sundsvall.petinventory.integration.petstore.configuration;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import java.util.List;
-
 import org.springframework.cloud.openfeign.FeignBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
-
 import se.sundsvall.dept44.configuration.feign.FeignConfiguration;
 import se.sundsvall.dept44.configuration.feign.FeignMultiCustomizer;
 import se.sundsvall.dept44.configuration.feign.decoder.ProblemErrorDecoder;

--- a/dept44-example/src/main/java/se/sundsvall/petinventory/service/PetInventoryService.java
+++ b/dept44-example/src/main/java/se/sundsvall/petinventory/service/PetInventoryService.java
@@ -6,12 +6,10 @@ import static se.sundsvall.petinventory.service.mapper.PetInventoryMapper.toPetI
 
 import java.util.List;
 import java.util.Objects;
-
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import org.zalando.problem.Problem;
 import org.zalando.problem.Status;
-
 import se.sundsvall.petinventory.api.model.PetInventoryItem;
 import se.sundsvall.petinventory.integration.db.PetImageRepository;
 import se.sundsvall.petinventory.integration.db.PetNameRepository;

--- a/dept44-example/src/main/java/se/sundsvall/petinventory/service/mapper/PetInventoryMapper.java
+++ b/dept44-example/src/main/java/se/sundsvall/petinventory/service/mapper/PetInventoryMapper.java
@@ -3,12 +3,10 @@ package se.sundsvall.petinventory.service.mapper;
 import static java.util.Collections.emptyList;
 import static java.util.Objects.isNull;
 
+import generated.swagger.io.petstore.Pet;
 import java.util.List;
 import java.util.Optional;
-
 import org.apache.commons.lang3.ObjectUtils;
-
-import generated.swagger.io.petstore.Pet;
 import se.sundsvall.petinventory.api.model.PetImage;
 import se.sundsvall.petinventory.api.model.PetInventoryItem;
 import se.sundsvall.petinventory.integration.db.model.PetImageEntity;

--- a/dept44-example/src/test/java/se/sundsvall/petinventory/api/PetInventoryResourceTest.java
+++ b/dept44-example/src/test/java/se/sundsvall/petinventory/api/PetInventoryResourceTest.java
@@ -14,7 +14,6 @@ import static org.springframework.http.MediaType.MULTIPART_FORM_DATA;
 
 import java.io.IOException;
 import java.util.List;
-
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -26,7 +25,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.reactive.function.BodyInserters;
-
 import se.sundsvall.petinventory.Application;
 import se.sundsvall.petinventory.api.model.PetInventoryItem;
 import se.sundsvall.petinventory.integration.db.model.PetImageEntity;

--- a/dept44-example/src/test/java/se/sundsvall/petinventory/api/model/PetInventoryItemTest.java
+++ b/dept44-example/src/test/java/se/sundsvall/petinventory/api/model/PetInventoryItemTest.java
@@ -10,7 +10,6 @@ import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.List;
-
 import org.junit.jupiter.api.Test;
 
 class PetInventoryItemTest {

--- a/dept44-example/src/test/java/se/sundsvall/petinventory/integration/db/PetImageRepositoryTest.java
+++ b/dept44-example/src/test/java/se/sundsvall/petinventory/integration/db/PetImageRepositoryTest.java
@@ -11,7 +11,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
-
 import se.sundsvall.petinventory.integration.db.model.PetImageEntity;
 import se.sundsvall.petinventory.integration.db.model.PetNameEntity;
 

--- a/dept44-example/src/test/java/se/sundsvall/petinventory/integration/db/PetNameRepositoryTest.java
+++ b/dept44-example/src/test/java/se/sundsvall/petinventory/integration/db/PetNameRepositoryTest.java
@@ -10,7 +10,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
-
 import se.sundsvall.petinventory.integration.db.model.PetNameEntity;
 
 /**

--- a/dept44-example/src/test/java/se/sundsvall/petinventory/integration/db/SchemaVerificationTest.java
+++ b/dept44-example/src/test/java/se/sundsvall/petinventory/integration/db/SchemaVerificationTest.java
@@ -1,17 +1,16 @@
 package se.sundsvall.petinventory.integration.db;
 
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles("junit")

--- a/dept44-example/src/test/java/se/sundsvall/petinventory/integration/db/model/PetImageEntityTest.java
+++ b/dept44-example/src/test/java/se/sundsvall/petinventory/integration/db/model/PetImageEntityTest.java
@@ -13,7 +13,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.time.OffsetDateTime;
 import java.util.Random;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 

--- a/dept44-example/src/test/java/se/sundsvall/petinventory/integration/db/model/PetNameEntityTest.java
+++ b/dept44-example/src/test/java/se/sundsvall/petinventory/integration/db/model/PetNameEntityTest.java
@@ -14,7 +14,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Random;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 

--- a/dept44-example/src/test/java/se/sundsvall/petinventory/integration/db/model/listener/PetImageEntityListenerTest.java
+++ b/dept44-example/src/test/java/se/sundsvall/petinventory/integration/db/model/listener/PetImageEntityListenerTest.java
@@ -6,7 +6,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
 
 import org.junit.jupiter.api.Test;
-
 import se.sundsvall.petinventory.integration.db.model.PetImageEntity;
 
 class PetImageEntityListenerTest {

--- a/dept44-example/src/test/java/se/sundsvall/petinventory/integration/db/model/listener/PetNameEntityListenerTest.java
+++ b/dept44-example/src/test/java/se/sundsvall/petinventory/integration/db/model/listener/PetNameEntityListenerTest.java
@@ -6,7 +6,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
 
 import org.junit.jupiter.api.Test;
-
 import se.sundsvall.petinventory.integration.db.model.PetNameEntity;
 
 class PetNameEntityListenerTest {

--- a/dept44-example/src/test/java/se/sundsvall/petinventory/integration/petstore/configuration/PetStoreConfigurationTest.java
+++ b/dept44-example/src/test/java/se/sundsvall/petinventory/integration/petstore/configuration/PetStoreConfigurationTest.java
@@ -6,8 +6,8 @@ import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static se.sundsvall.petinventory.integration.petstore.configuration.PetStoreConfiguration.CLIENT_ID;
 
+import feign.codec.ErrorDecoder;
 import java.util.List;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -20,8 +20,6 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
-
-import feign.codec.ErrorDecoder;
 import se.sundsvall.dept44.configuration.feign.FeignMultiCustomizer;
 import se.sundsvall.dept44.configuration.feign.decoder.ProblemErrorDecoder;
 

--- a/dept44-example/src/test/java/se/sundsvall/petinventory/integration/petstore/configuration/PetStorePropertiesTest.java
+++ b/dept44-example/src/test/java/se/sundsvall/petinventory/integration/petstore/configuration/PetStorePropertiesTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-
 import se.sundsvall.petinventory.Application;
 
 @SpringBootTest(classes = Application.class)

--- a/dept44-example/src/test/java/se/sundsvall/petinventory/service/PetInventoryServiceTest.java
+++ b/dept44-example/src/test/java/se/sundsvall/petinventory/service/PetInventoryServiceTest.java
@@ -9,18 +9,16 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.zalando.problem.Status.NOT_FOUND;
 
+import generated.swagger.io.petstore.Pet;
+import generated.swagger.io.petstore.TypeEnum;
 import java.util.List;
 import java.util.Optional;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.zalando.problem.ThrowableProblem;
-
-import generated.swagger.io.petstore.Pet;
-import generated.swagger.io.petstore.TypeEnum;
 import se.sundsvall.petinventory.api.model.PetInventoryItem;
 import se.sundsvall.petinventory.integration.db.PetImageRepository;
 import se.sundsvall.petinventory.integration.db.PetNameRepository;

--- a/dept44-example/src/test/java/se/sundsvall/petinventory/service/mapper/PetInventoryMapperTest.java
+++ b/dept44-example/src/test/java/se/sundsvall/petinventory/service/mapper/PetInventoryMapperTest.java
@@ -3,12 +3,10 @@ package se.sundsvall.petinventory.service.mapper;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
-import java.util.List;
-
-import org.junit.jupiter.api.Test;
-
 import generated.swagger.io.petstore.Pet;
 import generated.swagger.io.petstore.TypeEnum;
+import java.util.List;
+import org.junit.jupiter.api.Test;
 import se.sundsvall.petinventory.api.model.PetImage;
 import se.sundsvall.petinventory.integration.db.model.PetImageEntity;
 

--- a/dept44-formatting-plugin/pom.xml
+++ b/dept44-formatting-plugin/pom.xml
@@ -59,14 +59,20 @@
 				<artifactId>spotless-maven-plugin</artifactId>
 				<configuration>
 					<java>
+						<toggleOffOn />
 						<excludes>
 							<exclude>**/target/**</exclude>
 						</excludes>
 						<eclipse>
 							<file>src/main/resources/sundsvall_formatting.xml</file>
 						</eclipse>
+						<importOrder />
+						<removeUnusedImports>
+							<engine>cleanthat-javaparser-unnecessaryimport</engine>
+						</removeUnusedImports>
 					</java>
 					<json>
+						<toggleOffOn />
 						<excludes>
 							<exclude>**/target/**</exclude>
 						</excludes>
@@ -80,6 +86,7 @@
 						</indent>
 					</json>
 					<sql>
+						<toggleOffOn />
 						<excludes>
 							<exclude>**/target/**</exclude>
 						</excludes>
@@ -93,6 +100,7 @@
 						<dbeaver />
 					</sql>
 					<markdown>
+						<toggleOffOn />
 						<excludes>
 							<exclude>**/target/**</exclude>
 						</excludes>
@@ -102,6 +110,7 @@
 						<flexmark />
 					</markdown>
 					<pom>
+						<toggleOffOn />
 						<includes>
 							<include>pom.xml</include>
 						</includes>

--- a/dept44-formatting-plugin/src/main/java/se/sundsvall/dept44/AbstractFormatMojo.java
+++ b/dept44-formatting-plugin/src/main/java/se/sundsvall/dept44/AbstractFormatMojo.java
@@ -1,5 +1,12 @@
 package se.sundsvall.dept44;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+import java.util.Optional;
+import javax.inject.Inject;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.BuildPluginManager;
@@ -10,14 +17,6 @@ import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.twdata.maven.mojoexecutor.MojoExecutor;
-
-import javax.inject.Inject;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Objects;
-import java.util.Optional;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 public abstract class AbstractFormatMojo extends AbstractMojo {
 

--- a/dept44-formatting-plugin/src/main/java/se/sundsvall/dept44/ApplyFormatMojo.java
+++ b/dept44-formatting-plugin/src/main/java/se/sundsvall/dept44/ApplyFormatMojo.java
@@ -1,10 +1,9 @@
 package se.sundsvall.dept44;
 
+import javax.inject.Inject;
 import org.apache.maven.plugin.BuildPluginManager;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
-
-import javax.inject.Inject;
 
 @Mojo(name = "apply", defaultPhase = LifecyclePhase.VALIDATE)
 public class ApplyFormatMojo extends AbstractFormatMojo {

--- a/dept44-formatting-plugin/src/main/java/se/sundsvall/dept44/CheckFormatMojo.java
+++ b/dept44-formatting-plugin/src/main/java/se/sundsvall/dept44/CheckFormatMojo.java
@@ -1,10 +1,9 @@
 package se.sundsvall.dept44;
 
+import javax.inject.Inject;
 import org.apache.maven.plugin.BuildPluginManager;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
-
-import javax.inject.Inject;
 
 @Mojo(name = "check", defaultPhase = LifecyclePhase.VALIDATE)
 public class CheckFormatMojo extends AbstractFormatMojo {

--- a/dept44-formatting-plugin/src/main/resources/config.xml
+++ b/dept44-formatting-plugin/src/main/resources/config.xml
@@ -1,13 +1,19 @@
 <configuration>
 	<java>
+		<toggleOffOn />
 		<excludes>
 			<exclude>**/target/**</exclude>
 		</excludes>
 		<eclipse>
 			<file>src/main/resources/sundsvall_formatting.xml</file>
 		</eclipse>
+		<importOrder />
+		<removeUnusedImports>
+			<engine>cleanthat-javaparser-unnecessaryimport</engine>
+		</removeUnusedImports>
 	</java>
 	<json>
+		<toggleOffOn />
 		<excludes>
 			<exclude>**/target/**</exclude>
 		</excludes>
@@ -21,6 +27,7 @@
 		</indent>
 	</json>
 	<sql>
+		<toggleOffOn />
 		<excludes>
 			<exclude>**/target/**</exclude>
 		</excludes>
@@ -34,6 +41,7 @@
 		<dbeaver />
 	</sql>
 	<markdown>
+		<toggleOffOn />
 		<excludes>
 			<exclude>**/target/**</exclude>
 		</excludes>
@@ -43,6 +51,7 @@
 		<flexmark />
 	</markdown>
 	<pom>
+		<toggleOffOn />
 		<includes>
 			<include>pom.xml</include>
 		</includes>

--- a/dept44-formatting-plugin/src/test/java/se/sundsvall/dept44/ApplyFormatMojoTest.java
+++ b/dept44-formatting-plugin/src/test/java/se/sundsvall/dept44/ApplyFormatMojoTest.java
@@ -1,5 +1,16 @@
 package se.sundsvall.dept44;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.artifactId;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.groupId;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.plugin;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.version;
+
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.BuildPluginManager;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
@@ -12,17 +23,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.same;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.twdata.maven.mojoexecutor.MojoExecutor.artifactId;
-import static org.twdata.maven.mojoexecutor.MojoExecutor.groupId;
-import static org.twdata.maven.mojoexecutor.MojoExecutor.plugin;
-import static org.twdata.maven.mojoexecutor.MojoExecutor.version;
 
 @ExtendWith(MockitoExtension.class)
 class ApplyFormatMojoTest {

--- a/dept44-formatting-plugin/src/test/java/se/sundsvall/dept44/CheckFormatMojoTest.java
+++ b/dept44-formatting-plugin/src/test/java/se/sundsvall/dept44/CheckFormatMojoTest.java
@@ -1,5 +1,16 @@
 package se.sundsvall.dept44;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.artifactId;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.groupId;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.plugin;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.version;
+
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.BuildPluginManager;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
@@ -12,17 +23,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.same;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.twdata.maven.mojoexecutor.MojoExecutor.artifactId;
-import static org.twdata.maven.mojoexecutor.MojoExecutor.groupId;
-import static org.twdata.maven.mojoexecutor.MojoExecutor.plugin;
-import static org.twdata.maven.mojoexecutor.MojoExecutor.version;
 
 @ExtendWith(MockitoExtension.class)
 class CheckFormatMojoTest {

--- a/dept44-models/src/main/java/se/sundsvall/dept44/models/api/paging/AbstractParameterPagingAndSortingBase.java
+++ b/dept44-models/src/main/java/se/sundsvall/dept44/models/api/paging/AbstractParameterPagingAndSortingBase.java
@@ -1,17 +1,16 @@
 package se.sundsvall.dept44.models.api.paging;
 
+import static org.springframework.data.domain.Sort.DEFAULT_DIRECTION;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.Optional;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.data.domain.Sort;
-
-import java.util.List;
-import java.util.Optional;
-
-import static org.springframework.data.domain.Sort.DEFAULT_DIRECTION;
 
 /**
  * Model class to extend when requesting paged result with sorting. Should be used as query parameters.

--- a/dept44-models/src/main/java/se/sundsvall/dept44/models/api/paging/PagingAndSortingMetaData.java
+++ b/dept44-models/src/main/java/se/sundsvall/dept44/models/api/paging/PagingAndSortingMetaData.java
@@ -4,16 +4,14 @@ import static io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY;
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.toList;
 
-import java.util.List;
-
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Sort;
-
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Sort;
 
 /**
  * Model class to use when returning paged result with sorting. Should be added in root of response under attribute

--- a/dept44-models/src/main/java/se/sundsvall/dept44/models/api/paging/PagingMetaData.java
+++ b/dept44-models/src/main/java/se/sundsvall/dept44/models/api/paging/PagingMetaData.java
@@ -1,9 +1,9 @@
 package se.sundsvall.dept44.models.api.paging;
 
+import static io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
-
-import static io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY;
 
 /**
  * Model class to use when returning paged result. Should be added in root of response under attribute "_meta".

--- a/dept44-models/src/main/java/se/sundsvall/dept44/models/api/paging/validation/MaxPagingLimit.java
+++ b/dept44-models/src/main/java/se/sundsvall/dept44/models/api/paging/validation/MaxPagingLimit.java
@@ -2,13 +2,12 @@ package se.sundsvall.dept44.models.api.paging.validation;
 
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
-import se.sundsvall.dept44.models.api.paging.validation.impl.MaxPagingLimitConstraintValidator;
-
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import se.sundsvall.dept44.models.api.paging.validation.impl.MaxPagingLimitConstraintValidator;
 
 @Documented
 @Target({

--- a/dept44-models/src/main/java/se/sundsvall/dept44/models/api/paging/validation/ValidSortByProperty.java
+++ b/dept44-models/src/main/java/se/sundsvall/dept44/models/api/paging/validation/ValidSortByProperty.java
@@ -2,13 +2,12 @@ package se.sundsvall.dept44.models.api.paging.validation;
 
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
-import se.sundsvall.dept44.models.api.paging.validation.impl.ValidSortByPropertyConstraintValidator;
-
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import se.sundsvall.dept44.models.api.paging.validation.impl.ValidSortByPropertyConstraintValidator;
 
 /**
  * Validates that sortBy properties of {@link se.sundsvall.dept44.models.api.paging.AbstractParameterPagingBase} is

--- a/dept44-models/src/main/java/se/sundsvall/dept44/models/api/paging/validation/impl/ValidSortByPropertyConstraintValidator.java
+++ b/dept44-models/src/main/java/se/sundsvall/dept44/models/api/paging/validation/impl/ValidSortByPropertyConstraintValidator.java
@@ -1,22 +1,21 @@
 package se.sundsvall.dept44.models.api.paging.validation.impl;
 
+import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.toList;
+import static org.springframework.util.CollectionUtils.isEmpty;
+
 import jakarta.persistence.Column;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
-import org.hibernate.validator.internal.engine.messageinterpolation.util.InterpolationHelper;
-import se.sundsvall.dept44.models.api.paging.AbstractParameterPagingAndSortingBase;
-import se.sundsvall.dept44.models.api.paging.validation.ValidSortByProperty;
-
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
-
-import static java.util.stream.Collectors.collectingAndThen;
-import static java.util.stream.Collectors.toList;
-import static org.springframework.util.CollectionUtils.isEmpty;
+import org.hibernate.validator.internal.engine.messageinterpolation.util.InterpolationHelper;
+import se.sundsvall.dept44.models.api.paging.AbstractParameterPagingAndSortingBase;
+import se.sundsvall.dept44.models.api.paging.validation.ValidSortByProperty;
 
 public class ValidSortByPropertyConstraintValidator implements ConstraintValidator<ValidSortByProperty, AbstractParameterPagingAndSortingBase> {
 

--- a/dept44-models/src/test/java/se/sundsvall/dept44/models/api/paging/AbstractParameterPagingAndSortingBaseTest.java
+++ b/dept44-models/src/test/java/se/sundsvall/dept44/models/api/paging/AbstractParameterPagingAndSortingBaseTest.java
@@ -1,10 +1,5 @@
 package se.sundsvall.dept44.models.api.paging;
 
-import org.junit.jupiter.api.Test;
-import org.springframework.data.domain.Sort;
-
-import java.util.List;
-
 import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanConstructor;
 import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanEquals;
 import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanHashCode;
@@ -15,6 +10,10 @@ import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.springframework.data.domain.Sort.Direction.ASC;
 import static org.springframework.data.domain.Sort.Direction.DESC;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Sort;
 
 class AbstractParameterPagingAndSortingBaseTest {
 

--- a/dept44-models/src/test/java/se/sundsvall/dept44/models/api/paging/AbstractParameterPagingBaseTest.java
+++ b/dept44-models/src/test/java/se/sundsvall/dept44/models/api/paging/AbstractParameterPagingBaseTest.java
@@ -1,7 +1,5 @@
 package se.sundsvall.dept44.models.api.paging;
 
-import org.junit.jupiter.api.Test;
-
 import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanConstructor;
 import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanEquals;
 import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanHashCode;
@@ -9,6 +7,8 @@ import static com.google.code.beanmatchers.BeanMatchers.hasValidGettersAndSetter
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.jupiter.api.Test;
 
 class AbstractParameterPagingBaseTest {
 

--- a/dept44-models/src/test/java/se/sundsvall/dept44/models/api/paging/PagingAndSortingMetaDataTest.java
+++ b/dept44-models/src/test/java/se/sundsvall/dept44/models/api/paging/PagingAndSortingMetaDataTest.java
@@ -1,12 +1,5 @@
 package se.sundsvall.dept44.models.api.paging;
 
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Sort;
-
-import java.util.List;
-
 import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanConstructor;
 import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanEquals;
 import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanHashCode;
@@ -16,6 +9,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Sort;
 
 class PagingAndSortingMetaDataTest {
 

--- a/dept44-models/src/test/java/se/sundsvall/dept44/models/api/paging/PagingMetaDataTest.java
+++ b/dept44-models/src/test/java/se/sundsvall/dept44/models/api/paging/PagingMetaDataTest.java
@@ -1,7 +1,5 @@
 package se.sundsvall.dept44.models.api.paging;
 
-import org.junit.jupiter.api.Test;
-
 import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanConstructor;
 import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanEquals;
 import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanHashCode;
@@ -10,6 +8,8 @@ import static com.google.code.beanmatchers.BeanMatchers.hasValidGettersAndSetter
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.jupiter.api.Test;
 
 class PagingMetaDataTest {
 

--- a/dept44-models/src/test/java/se/sundsvall/dept44/models/api/paging/validation/impl/MaxPagingLimitImplTest.java
+++ b/dept44-models/src/test/java/se/sundsvall/dept44/models/api/paging/validation/impl/MaxPagingLimitImplTest.java
@@ -1,5 +1,10 @@
 package se.sundsvall.dept44.models.api.paging.validation.impl;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import jakarta.validation.ConstraintValidatorContext;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;
@@ -13,11 +18,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 import se.sundsvall.dept44.models.api.paging.AbstractParameterPagingBase;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @SpringBootTest(classes = {

--- a/dept44-models/src/test/java/se/sundsvall/dept44/models/api/paging/validation/impl/ValidSortByPropertyConstraintValidatorTest.java
+++ b/dept44-models/src/test/java/se/sundsvall/dept44/models/api/paging/validation/impl/ValidSortByPropertyConstraintValidatorTest.java
@@ -2,18 +2,16 @@ package se.sundsvall.dept44.models.api.paging.validation.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import jakarta.persistence.Column;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
 import java.util.List;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
-
-import jakarta.persistence.Column;
-import jakarta.validation.ConstraintViolation;
-import jakarta.validation.Validator;
 import se.sundsvall.dept44.models.api.paging.AbstractParameterPagingAndSortingBase;
 import se.sundsvall.dept44.models.api.paging.validation.ValidSortByProperty;
 

--- a/dept44-starter-authorization/src/main/java/se/sundsvall/dept44/authorization/EnableJwtAuthorization.java
+++ b/dept44-starter-authorization/src/main/java/se/sundsvall/dept44/authorization/EnableJwtAuthorization.java
@@ -4,9 +4,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
 import org.springframework.context.annotation.Import;
-
 import se.sundsvall.dept44.authorization.configuration.JwtAuthorizationProperties;
 import se.sundsvall.dept44.authorization.configuration.PrePostMethodSecurityConfiguration;
 import se.sundsvall.dept44.authorization.configuration.UnauthorizedExceptionHandlerConfiguration;

--- a/dept44-starter-authorization/src/main/java/se/sundsvall/dept44/authorization/JwtAuthorizationExtractionFilter.java
+++ b/dept44-starter-authorization/src/main/java/se/sundsvall/dept44/authorization/JwtAuthorizationExtractionFilter.java
@@ -6,10 +6,19 @@ import static java.util.Optional.ofNullable;
 import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON_VALUE;
 import static org.zalando.problem.Status.UNAUTHORIZED;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import io.jsonwebtoken.security.WeakKeyException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Map.Entry;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
@@ -20,18 +29,6 @@ import org.springframework.security.web.authentication.WebAuthenticationDetailsS
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.zalando.problem.Problem;
 import org.zalando.problem.ThrowableProblem;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.UnsupportedJwtException;
-import io.jsonwebtoken.security.SignatureException;
-import io.jsonwebtoken.security.WeakKeyException;
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import se.sundsvall.dept44.ServiceApplication;
 import se.sundsvall.dept44.authorization.configuration.JwtAuthorizationProperties;
 import se.sundsvall.dept44.authorization.model.GenericGrantedAuthority;

--- a/dept44-starter-authorization/src/main/java/se/sundsvall/dept44/authorization/configuration/PrePostMethodSecurityConfiguration.java
+++ b/dept44-starter-authorization/src/main/java/se/sundsvall/dept44/authorization/configuration/PrePostMethodSecurityConfiguration.java
@@ -2,14 +2,12 @@ package se.sundsvall.dept44.authorization.configuration;
 
 import static org.springframework.util.Assert.hasText;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import se.sundsvall.dept44.authorization.JwtAuthorizationExtractionFilter;
 import se.sundsvall.dept44.authorization.util.JwtTokenUtil;
 

--- a/dept44-starter-authorization/src/main/java/se/sundsvall/dept44/authorization/configuration/UnauthorizedExceptionHandlerConfiguration.java
+++ b/dept44-starter-authorization/src/main/java/se/sundsvall/dept44/authorization/configuration/UnauthorizedExceptionHandlerConfiguration.java
@@ -1,15 +1,14 @@
 package se.sundsvall.dept44.authorization.configuration;
 
+import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON;
 import static org.zalando.problem.Status.UNAUTHORIZED;
 
 import java.util.Optional;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
-import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;

--- a/dept44-starter-authorization/src/main/java/se/sundsvall/dept44/authorization/model/GenericGrantedAuthority.java
+++ b/dept44-starter-authorization/src/main/java/se/sundsvall/dept44/authorization/model/GenericGrantedAuthority.java
@@ -3,16 +3,13 @@ package se.sundsvall.dept44.authorization.model;
 import static java.util.Objects.isNull;
 import static org.springframework.util.Assert.hasText;
 
-import java.util.Objects;
-
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.SpringSecurityCoreVersion;
-
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.InvalidPathException;
 import com.jayway.jsonpath.JsonPath;
-
+import java.util.Objects;
 import net.minidev.json.JSONArray;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.SpringSecurityCoreVersion;
 
 public class GenericGrantedAuthority implements GrantedAuthority {
 

--- a/dept44-starter-authorization/src/main/java/se/sundsvall/dept44/authorization/model/User.java
+++ b/dept44-starter-authorization/src/main/java/se/sundsvall/dept44/authorization/model/User.java
@@ -4,7 +4,6 @@ import static org.springframework.util.CollectionUtils.isEmpty;
 
 import java.util.ArrayList;
 import java.util.Collection;
-
 import org.springframework.security.core.userdetails.UserDetails;
 
 public class User implements UserDetails {

--- a/dept44-starter-authorization/src/main/java/se/sundsvall/dept44/authorization/model/UsernameAuthenticationToken.java
+++ b/dept44-starter-authorization/src/main/java/se/sundsvall/dept44/authorization/model/UsernameAuthenticationToken.java
@@ -4,7 +4,6 @@ import static org.springframework.util.Assert.isTrue;
 
 import java.util.Collection;
 import java.util.Objects;
-
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
 

--- a/dept44-starter-authorization/src/main/java/se/sundsvall/dept44/authorization/util/JwtTokenUtil.java
+++ b/dept44-starter-authorization/src/main/java/se/sundsvall/dept44/authorization/util/JwtTokenUtil.java
@@ -3,6 +3,9 @@ package se.sundsvall.dept44.authorization.util;
 import static java.util.Collections.emptyMap;
 import static org.springframework.util.Assert.hasText;
 
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
 import java.io.Serializable;
 import java.nio.charset.Charset;
 import java.util.Collection;
@@ -11,12 +14,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
-
 import org.springframework.stereotype.Component;
-
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.security.Keys;
 import se.sundsvall.dept44.authorization.model.GenericGrantedAuthority;
 
 @Component

--- a/dept44-starter-authorization/src/test/java/se/sundsvall/dept44/authorization/EnableJwtAuthorizationTest.java
+++ b/dept44-starter-authorization/src/test/java/se/sundsvall/dept44/authorization/EnableJwtAuthorizationTest.java
@@ -1,16 +1,14 @@
 package se.sundsvall.dept44.authorization;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.core.annotation.AnnotationUtils.getAnnotation;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
 import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.Import;
-import static org.springframework.core.annotation.AnnotationUtils.getAnnotation;
-
 import se.sundsvall.dept44.authorization.configuration.JwtAuthorizationProperties;
 import se.sundsvall.dept44.authorization.configuration.PrePostMethodSecurityConfiguration;
 import se.sundsvall.dept44.authorization.configuration.UnauthorizedExceptionHandlerConfiguration;

--- a/dept44-starter-authorization/src/test/java/se/sundsvall/dept44/authorization/JwtAuthorizationExtractionFilterTest.java
+++ b/dept44-starter-authorization/src/test/java/se/sundsvall/dept44/authorization/JwtAuthorizationExtractionFilterTest.java
@@ -9,15 +9,20 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.CompressionException;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import io.jsonwebtoken.security.WeakKeyException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.PrintWriter;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
-
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -36,15 +41,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.zalando.problem.Status;
 import org.zalando.problem.ThrowableProblem;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import io.jsonwebtoken.CompressionException;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.UnsupportedJwtException;
-import io.jsonwebtoken.security.SignatureException;
-import io.jsonwebtoken.security.WeakKeyException;
 import se.sundsvall.dept44.ServiceApplication;
 import se.sundsvall.dept44.authorization.configuration.JwtAuthorizationProperties;
 import se.sundsvall.dept44.authorization.model.GenericGrantedAuthority;

--- a/dept44-starter-authorization/src/test/java/se/sundsvall/dept44/authorization/configuration/PrePostMethodSecurityConfigurationTest.java
+++ b/dept44-starter-authorization/src/test/java/se/sundsvall/dept44/authorization/configuration/PrePostMethodSecurityConfigurationTest.java
@@ -3,8 +3,8 @@ package se.sundsvall.dept44.authorization.configuration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.core.annotation.AnnotationUtils.getAnnotation;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.stream.Stream;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -15,9 +15,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.util.ReflectionUtils;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import se.sundsvall.dept44.authorization.JwtAuthorizationExtractionFilter;
 import se.sundsvall.dept44.authorization.util.JwtTokenUtil;
 

--- a/dept44-starter-authorization/src/test/java/se/sundsvall/dept44/authorization/configuration/UnauthorizedExceptionHandlerConfigurationTest.java
+++ b/dept44-starter-authorization/src/test/java/se/sundsvall/dept44/authorization/configuration/UnauthorizedExceptionHandlerConfigurationTest.java
@@ -5,7 +5,6 @@ import static org.springframework.core.annotation.AnnotationUtils.getAnnotation;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 import java.util.stream.Stream;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -18,7 +17,6 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.zalando.problem.Status;
-
 import se.sundsvall.dept44.authorization.configuration.UnauthorizedExceptionHandlerConfiguration.AccessDeniedExceptionHandler;
 import se.sundsvall.dept44.authorization.configuration.UnauthorizedExceptionHandlerConfiguration.AuthenticationCredentialsNotFoundExceptionHandler;
 

--- a/dept44-starter-authorization/src/test/java/se/sundsvall/dept44/authorization/model/UserTest.java
+++ b/dept44-starter-authorization/src/test/java/se/sundsvall/dept44/authorization/model/UserTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import org.junit.jupiter.api.Test;
 import org.springframework.security.core.userdetails.UserDetails;
 

--- a/dept44-starter-authorization/src/test/java/se/sundsvall/dept44/authorization/model/UsernameAuthenticationTokenTest.java
+++ b/dept44-starter-authorization/src/test/java/se/sundsvall/dept44/authorization/model/UsernameAuthenticationTokenTest.java
@@ -6,7 +6,6 @@ import static se.sundsvall.dept44.authorization.model.UsernameAuthenticationToke
 import static se.sundsvall.dept44.authorization.model.UsernameAuthenticationToken.unauthenticated;
 
 import java.util.List;
-
 import org.junit.jupiter.api.Test;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 

--- a/dept44-starter-authorization/src/test/java/se/sundsvall/dept44/authorization/util/JwtTokenUtilTest.java
+++ b/dept44-starter-authorization/src/test/java/se/sundsvall/dept44/authorization/util/JwtTokenUtilTest.java
@@ -3,17 +3,15 @@ package se.sundsvall.dept44.authorization.util;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.time.Instant;
-
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.core.annotation.AnnotationUtils;
-import org.springframework.stereotype.Component;
-
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.security.SignatureException;
 import io.jsonwebtoken.security.WeakKeyException;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.stereotype.Component;
 import se.sundsvall.dept44.authorization.model.GenericGrantedAuthority;
 import se.sundsvall.dept44.test.annotation.resource.Load;
 import se.sundsvall.dept44.test.extension.ResourceLoaderExtension;

--- a/dept44-starter-feign/src/main/java/se/sundsvall/dept44/configuration/feign/FeignConfiguration.java
+++ b/dept44-starter-feign/src/main/java/se/sundsvall/dept44/configuration/feign/FeignConfiguration.java
@@ -1,13 +1,11 @@
 package se.sundsvall.dept44.configuration.feign;
 
-import javax.net.ssl.X509TrustManager;
-
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
-import org.springframework.context.annotation.Bean;
-
 import feign.Client;
 import feign.Logger;
 import feign.okhttp.OkHttpClient;
+import javax.net.ssl.X509TrustManager;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.context.annotation.Bean;
 import se.sundsvall.dept44.security.Truststore;
 
 public class FeignConfiguration {

--- a/dept44-starter-feign/src/main/java/se/sundsvall/dept44/configuration/feign/FeignMultiCustomizer.java
+++ b/dept44-starter-feign/src/main/java/se/sundsvall/dept44/configuration/feign/FeignMultiCustomizer.java
@@ -2,19 +2,17 @@ package se.sundsvall.dept44.configuration.feign;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
-
-import org.springframework.cloud.openfeign.FeignBuilderCustomizer;
-import org.springframework.security.oauth2.client.registration.ClientRegistration;
-
 import feign.Request;
 import feign.RequestInterceptor;
 import feign.codec.Decoder;
 import feign.codec.Encoder;
 import feign.codec.ErrorDecoder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.springframework.cloud.openfeign.FeignBuilderCustomizer;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import se.sundsvall.dept44.configuration.feign.interceptor.OAuth2RequestInterceptor;
 import se.sundsvall.dept44.configuration.feign.retryer.ActionRetryer;
 import se.sundsvall.dept44.requestid.RequestId;

--- a/dept44-starter-feign/src/main/java/se/sundsvall/dept44/configuration/feign/decoder/AbstractErrorDecoder.java
+++ b/dept44-starter-feign/src/main/java/se/sundsvall/dept44/configuration/feign/decoder/AbstractErrorDecoder.java
@@ -8,23 +8,21 @@ import static java.util.Optional.ofNullable;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.zalando.problem.Status.BAD_GATEWAY;
 
+import feign.Response;
+import feign.RetryableException;
+import feign.codec.ErrorDecoder;
+import jakarta.annotation.Nonnull;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.SortedMap;
 import java.util.TreeMap;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus.Series;
 import org.zalando.problem.Problem;
 import org.zalando.problem.Status;
-
-import feign.Response;
-import feign.RetryableException;
-import feign.codec.ErrorDecoder;
-import jakarta.annotation.Nonnull;
 import se.sundsvall.dept44.exception.ClientProblem;
 import se.sundsvall.dept44.exception.ServerProblem;
 

--- a/dept44-starter-feign/src/main/java/se/sundsvall/dept44/configuration/feign/decoder/JsonPathErrorDecoder.java
+++ b/dept44-starter-feign/src/main/java/se/sundsvall/dept44/configuration/feign/decoder/JsonPathErrorDecoder.java
@@ -3,15 +3,12 @@ package se.sundsvall.dept44.configuration.feign.decoder;
 import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
 
-import java.io.IOException;
-import java.util.List;
-
-import jakarta.annotation.Nonnull;
-
 import com.jayway.jsonpath.JsonPath;
-
 import feign.Response;
 import feign.RetryableException;
+import jakarta.annotation.Nonnull;
+import java.io.IOException;
+import java.util.List;
 
 /**
  * A flexible ErrorDecoder that allows you to massage an error response into a application-specific one using JsonPath.

--- a/dept44-starter-feign/src/main/java/se/sundsvall/dept44/configuration/feign/decoder/ProblemErrorDecoder.java
+++ b/dept44-starter-feign/src/main/java/se/sundsvall/dept44/configuration/feign/decoder/ProblemErrorDecoder.java
@@ -3,19 +3,16 @@ package se.sundsvall.dept44.configuration.feign.decoder;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static se.sundsvall.dept44.configuration.feign.decoder.util.ProblemUtils.toProblem;
 
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import feign.Response;
+import feign.RetryableException;
+import jakarta.annotation.Nonnull;
 import java.io.IOException;
 import java.util.List;
-
 import org.zalando.problem.Problem;
 import org.zalando.problem.jackson.ProblemModule;
 import org.zalando.problem.violations.ConstraintViolationProblem;
 import org.zalando.problem.violations.ConstraintViolationProblemModule;
-
-import com.fasterxml.jackson.databind.json.JsonMapper;
-
-import feign.Response;
-import feign.RetryableException;
-import jakarta.annotation.Nonnull;
 
 /**
  * A Problem ErrorDecoder that allows you to process an Problem-based error response.

--- a/dept44-starter-feign/src/main/java/se/sundsvall/dept44/configuration/feign/decoder/WSO2RetryResponseVerifier.java
+++ b/dept44-starter-feign/src/main/java/se/sundsvall/dept44/configuration/feign/decoder/WSO2RetryResponseVerifier.java
@@ -3,11 +3,9 @@ package se.sundsvall.dept44.configuration.feign.decoder;
 import static java.util.Objects.nonNull;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
-import java.util.regex.Pattern;
-
-import org.apache.hc.core5.http.HttpHeaders;
-
 import feign.Response;
+import java.util.regex.Pattern;
+import org.apache.hc.core5.http.HttpHeaders;
 
 public class WSO2RetryResponseVerifier implements RetryResponseVerifier {
 

--- a/dept44-starter-feign/src/main/java/se/sundsvall/dept44/configuration/feign/decoder/util/ProblemUtils.java
+++ b/dept44-starter-feign/src/main/java/se/sundsvall/dept44/configuration/feign/decoder/util/ProblemUtils.java
@@ -4,7 +4,6 @@ import static java.util.stream.Collectors.joining;
 
 import java.util.List;
 import java.util.Optional;
-
 import org.zalando.problem.Problem;
 import org.zalando.problem.violations.ConstraintViolationProblem;
 import org.zalando.problem.violations.Violation;

--- a/dept44-starter-feign/src/main/java/se/sundsvall/dept44/configuration/feign/interceptor/OAuth2RequestInterceptor.java
+++ b/dept44-starter-feign/src/main/java/se/sundsvall/dept44/configuration/feign/interceptor/OAuth2RequestInterceptor.java
@@ -5,9 +5,10 @@ import static java.util.Optional.ofNullable;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static se.sundsvall.dept44.util.ResourceUtils.requireNonNull;
 
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
 import java.util.HashSet;
 import java.util.Set;
-
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.AuthorityUtils;
@@ -20,9 +21,6 @@ import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
 import org.springframework.util.Assert;
-
-import feign.RequestInterceptor;
-import feign.RequestTemplate;
 
 public class OAuth2RequestInterceptor implements RequestInterceptor {
 

--- a/dept44-starter-feign/src/test/java/se/sundsvall/dept44/configuration/feign/FeignConfigurationTest.java
+++ b/dept44-starter-feign/src/test/java/se/sundsvall/dept44/configuration/feign/FeignConfigurationTest.java
@@ -6,9 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import feign.okhttp.OkHttpClient;
 import java.lang.reflect.Method;
 import java.util.List;
-
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -16,8 +16,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.zalando.logbook.Logbook;
-
-import feign.okhttp.OkHttpClient;
 import se.sundsvall.dept44.security.Truststore;
 
 @SpringBootTest(classes = {

--- a/dept44-starter-feign/src/test/java/se/sundsvall/dept44/configuration/feign/FeignMultiCustomizerTest.java
+++ b/dept44-starter-feign/src/test/java/se/sundsvall/dept44/configuration/feign/FeignMultiCustomizerTest.java
@@ -8,8 +8,13 @@ import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 
+import feign.Feign;
+import feign.Request;
+import feign.RequestInterceptor;
+import feign.codec.Decoder;
+import feign.codec.Encoder;
+import feign.codec.ErrorDecoder;
 import java.util.Set;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -20,13 +25,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.cloud.openfeign.FeignBuilderCustomizer;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
-
-import feign.Feign;
-import feign.Request;
-import feign.RequestInterceptor;
-import feign.codec.Decoder;
-import feign.codec.Encoder;
-import feign.codec.ErrorDecoder;
 import se.sundsvall.dept44.configuration.feign.interceptor.OAuth2RequestInterceptor;
 import se.sundsvall.dept44.configuration.feign.retryer.ActionRetryer;
 

--- a/dept44-starter-feign/src/test/java/se/sundsvall/dept44/configuration/feign/decoder/JsonPathErrorDecoderTest.java
+++ b/dept44-starter-feign/src/test/java/se/sundsvall/dept44/configuration/feign/decoder/JsonPathErrorDecoderTest.java
@@ -11,12 +11,16 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static se.sundsvall.dept44.configuration.feign.decoder.WSO2RetryResponseVerifierTest.WSO2_TOKEN_EXPIRE_HEADER_ERROR;
 
+import feign.Request;
+import feign.RequestTemplate;
+import feign.Response;
+import feign.RetryableException;
+import feign.codec.ErrorDecoder;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -25,12 +29,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 import org.zalando.problem.Problem;
 import org.zalando.problem.ThrowableProblem;
-
-import feign.Request;
-import feign.RequestTemplate;
-import feign.Response;
-import feign.RetryableException;
-import feign.codec.ErrorDecoder;
 import se.sundsvall.dept44.configuration.feign.decoder.JsonPathErrorDecoder.JsonPathSetup;
 import se.sundsvall.dept44.exception.ClientProblem;
 import se.sundsvall.dept44.exception.ServerProblem;

--- a/dept44-starter-feign/src/test/java/se/sundsvall/dept44/configuration/feign/decoder/ProblemErrorDecoderTest.java
+++ b/dept44-starter-feign/src/test/java/se/sundsvall/dept44/configuration/feign/decoder/ProblemErrorDecoderTest.java
@@ -11,12 +11,16 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static se.sundsvall.dept44.configuration.feign.decoder.WSO2RetryResponseVerifierTest.WSO2_TOKEN_EXPIRE_HEADER_ERROR;
 
+import feign.Request;
+import feign.RequestTemplate;
+import feign.Response;
+import feign.RetryableException;
+import feign.codec.ErrorDecoder;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -25,12 +29,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 import org.zalando.problem.Problem;
 import org.zalando.problem.ThrowableProblem;
-
-import feign.Request;
-import feign.RequestTemplate;
-import feign.Response;
-import feign.RetryableException;
-import feign.codec.ErrorDecoder;
 import se.sundsvall.dept44.exception.ClientProblem;
 import se.sundsvall.dept44.exception.ServerProblem;
 import se.sundsvall.dept44.test.annotation.resource.Load;

--- a/dept44-starter-feign/src/test/java/se/sundsvall/dept44/configuration/feign/decoder/WSO2RetryResponseVerifierTest.java
+++ b/dept44-starter-feign/src/test/java/se/sundsvall/dept44/configuration/feign/decoder/WSO2RetryResponseVerifierTest.java
@@ -1,17 +1,16 @@
 package se.sundsvall.dept44.configuration.feign.decoder;
 
-import feign.Request;
-import feign.RequestTemplate;
-import feign.Response;
-import org.junit.jupiter.api.Test;
-
-import java.util.Map;
-import java.util.Set;
-
 import static feign.Request.HttpMethod.GET;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import feign.Request;
+import feign.RequestTemplate;
+import feign.Response;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
 
 class WSO2RetryResponseVerifierTest {
 

--- a/dept44-starter-feign/src/test/java/se/sundsvall/dept44/configuration/feign/decoder/util/ProblemUtilsTest.java
+++ b/dept44-starter-feign/src/test/java/se/sundsvall/dept44/configuration/feign/decoder/util/ProblemUtilsTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.zalando.problem.Status.BAD_REQUEST;
 
 import java.util.List;
-
 import org.junit.jupiter.api.Test;
 import org.zalando.problem.DefaultProblem;
 import org.zalando.problem.violations.ConstraintViolationProblem;

--- a/dept44-starter-feign/src/test/java/se/sundsvall/dept44/configuration/feign/interceptor/OAuth2RequestInterceptorTest.java
+++ b/dept44-starter-feign/src/test/java/se/sundsvall/dept44/configuration/feign/interceptor/OAuth2RequestInterceptorTest.java
@@ -20,15 +20,18 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import feign.Feign;
+import feign.RequestInterceptor;
+import feign.RequestLine;
+import feign.RequestTemplate;
+import feign.okhttp.OkHttpClient;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Pattern;
-
-import feign.Feign;
-import feign.RequestLine;
-import feign.okhttp.OkHttpClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -47,12 +50,6 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.test.util.ReflectionTestUtils;
-
-import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
-import com.github.tomakehurst.wiremock.junit5.WireMockTest;
-
-import feign.RequestInterceptor;
-import feign.RequestTemplate;
 import se.sundsvall.dept44.configuration.feign.FeignMultiCustomizer;
 import se.sundsvall.dept44.configuration.feign.decoder.ProblemErrorDecoder;
 

--- a/dept44-starter-feign/src/test/java/se/sundsvall/dept44/configuration/feign/retryer/ActionRetryerTest.java
+++ b/dept44-starter-feign/src/test/java/se/sundsvall/dept44/configuration/feign/retryer/ActionRetryerTest.java
@@ -6,11 +6,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-
 import feign.Request;
 import feign.RetryableException;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 class ActionRetryerTest {
 

--- a/dept44-starter-test/src/main/java/se/sundsvall/dept44/test/AbstractAppTest.java
+++ b/dept44-starter-test/src/main/java/se/sundsvall/dept44/test/AbstractAppTest.java
@@ -19,6 +19,17 @@ import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON;
 import static org.springframework.util.CollectionUtils.isEmpty;
 import static org.springframework.util.ResourceUtils.getFile;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.VerificationException;
+import com.github.tomakehurst.wiremock.common.ClasspathFileSource;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.extension.Extension;
+import com.github.tomakehurst.wiremock.standalone.JsonFileMappingsSource;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -32,7 +43,8 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.function.Function;
 import java.util.regex.Pattern;
-
+import net.javacrumbs.jsonunit.JsonAssert;
+import net.javacrumbs.jsonunit.core.Option;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,21 +62,6 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.util.ResourceUtils;
 import org.springframework.web.util.DefaultUriBuilderFactory;
 import org.springframework.web.util.UriBuilder;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.client.VerificationException;
-import com.github.tomakehurst.wiremock.common.ClasspathFileSource;
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
-import com.github.tomakehurst.wiremock.extension.Extension;
-import com.github.tomakehurst.wiremock.standalone.JsonFileMappingsSource;
-import com.github.tomakehurst.wiremock.verification.LoggedRequest;
-
-import net.javacrumbs.jsonunit.JsonAssert;
-import net.javacrumbs.jsonunit.core.Option;
 
 public abstract class AbstractAppTest {
 

--- a/dept44-starter-test/src/main/java/se/sundsvall/dept44/test/annotation/wiremock/WireMockAppTestSuite.java
+++ b/dept44-starter-test/src/main/java/se/sundsvall/dept44/test/annotation/wiremock/WireMockAppTestSuite.java
@@ -5,7 +5,6 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/dept44-starter-test/src/main/java/se/sundsvall/dept44/test/extension/ResourceLoaderExtension.java
+++ b/dept44-starter-test/src/main/java/se/sundsvall/dept44/test/extension/ResourceLoaderExtension.java
@@ -2,6 +2,9 @@ package se.sundsvall.dept44.test.extension;
 
 import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -9,17 +12,11 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 import org.junit.platform.commons.util.AnnotationUtils;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-
 import se.sundsvall.dept44.test.annotation.resource.Load;
 
 /**

--- a/dept44-starter-test/src/test/java/se/sundsvall/dept44/test/AbstractAppTestTest.java
+++ b/dept44-starter-test/src/test/java/se/sundsvall/dept44/test/AbstractAppTestTest.java
@@ -21,10 +21,18 @@ import static org.springframework.http.MediaType.IMAGE_JPEG;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
 
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.admin.model.ListStubMappingsResult;
+import com.github.tomakehurst.wiremock.common.FileSource;
+import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.extension.ResponseDefinitionTransformer;
+import com.github.tomakehurst.wiremock.standalone.JsonFileMappingsSource;
+import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import java.io.File;
 import java.nio.file.Files;
 import java.util.List;
-
+import net.javacrumbs.jsonunit.core.Option;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -37,17 +45,6 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.ResourceUtils;
-
-import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.admin.model.ListStubMappingsResult;
-import com.github.tomakehurst.wiremock.common.FileSource;
-import com.github.tomakehurst.wiremock.core.Options;
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
-import com.github.tomakehurst.wiremock.extension.ResponseDefinitionTransformer;
-import com.github.tomakehurst.wiremock.standalone.JsonFileMappingsSource;
-import com.github.tomakehurst.wiremock.stubbing.StubMapping;
-
-import net.javacrumbs.jsonunit.core.Option;
 import se.sundsvall.dept44.test.supportfiles.AppTestImplementation;
 import se.sundsvall.dept44.test.supportfiles.TestBody;
 

--- a/dept44-starter-test/src/test/java/se/sundsvall/dept44/test/extension/ResourceLoaderExtensionTest.java
+++ b/dept44-starter-test/src/test/java/se/sundsvall/dept44/test/extension/ResourceLoaderExtensionTest.java
@@ -1,17 +1,16 @@
 package se.sundsvall.dept44.test.extension;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import se.sundsvall.dept44.test.annotation.resource.Load;
 import se.sundsvall.dept44.test.extension.supportfiles.CustomTestExecutionExceptionHandler;
 import se.sundsvall.dept44.test.extension.supportfiles.TestObject;
-
-import java.time.OffsetDateTime;
-import java.time.format.DateTimeFormatter;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.fail;
 
 @ExtendWith(ResourceLoaderExtension.class)
 class ResourceLoaderExtensionTest {

--- a/dept44-starter-test/src/test/java/se/sundsvall/dept44/test/extension/supportfiles/CustomTestExecutionExceptionHandler.java
+++ b/dept44-starter-test/src/test/java/se/sundsvall/dept44/test/extension/supportfiles/CustomTestExecutionExceptionHandler.java
@@ -1,7 +1,6 @@
 package se.sundsvall.dept44.test.extension.supportfiles;
 
 import java.util.List;
-
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
 

--- a/dept44-starter-test/src/test/java/se/sundsvall/dept44/test/supportfiles/AppTestImplementation.java
+++ b/dept44-starter-test/src/test/java/se/sundsvall/dept44/test/supportfiles/AppTestImplementation.java
@@ -1,7 +1,6 @@
 package se.sundsvall.dept44.test.supportfiles;
 
 import org.springframework.test.context.ActiveProfiles;
-
 import se.sundsvall.dept44.test.AbstractAppTest;
 import se.sundsvall.dept44.test.annotation.wiremock.WireMockAppTestSuite;
 

--- a/dept44-starter-webclient/src/main/java/se/sundsvall/dept44/configuration/webclient/RequestIdExchangeFilterFunction.java
+++ b/dept44-starter-webclient/src/main/java/se/sundsvall/dept44/configuration/webclient/RequestIdExchangeFilterFunction.java
@@ -4,9 +4,7 @@ import org.springframework.web.reactive.function.client.ClientRequest;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import org.springframework.web.reactive.function.client.ExchangeFunction;
-
 import reactor.core.publisher.Mono;
-
 import se.sundsvall.dept44.requestid.RequestId;
 
 class RequestIdExchangeFilterFunction implements ExchangeFilterFunction {

--- a/dept44-starter-webclient/src/main/java/se/sundsvall/dept44/configuration/webclient/WebClientBuilder.java
+++ b/dept44-starter-webclient/src/main/java/se/sundsvall/dept44/configuration/webclient/WebClientBuilder.java
@@ -4,6 +4,9 @@ import static java.util.Optional.ofNullable;
 import static se.sundsvall.dept44.util.ResourceUtils.requireNonNull;
 import static se.sundsvall.dept44.util.ResourceUtils.requireNotBlank;
 
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -11,7 +14,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
-
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.security.oauth2.client.AuthorizedClientServiceReactiveOAuth2AuthorizedClientManager;
@@ -26,10 +28,6 @@ import org.springframework.web.reactive.function.client.support.WebClientAdapter
 import org.springframework.web.service.invoker.HttpServiceProxyFactory;
 import org.zalando.logbook.Logbook;
 import org.zalando.logbook.netty.LogbookClientHandler;
-
-import io.netty.channel.ChannelOption;
-import io.netty.handler.timeout.ReadTimeoutHandler;
-import io.netty.handler.timeout.WriteTimeoutHandler;
 import reactor.core.publisher.Mono;
 import reactor.netty.http.client.HttpClient;
 import se.sundsvall.dept44.configuration.Constants;

--- a/dept44-starter-webclient/src/test/java/se/sundsvall/dept44/configuration/webclient/WebClientBuilderTest.java
+++ b/dept44-starter-webclient/src/test/java/se/sundsvall/dept44/configuration/webclient/WebClientBuilderTest.java
@@ -8,9 +8,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
+import io.netty.channel.ChannelOption;
 import java.time.Duration;
 import java.util.Set;
-
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,8 +28,6 @@ import org.springframework.web.service.invoker.HttpServiceProxyFactory;
 import org.zalando.logbook.Logbook;
 import org.zalando.problem.Problem;
 import org.zalando.problem.Status;
-
-import io.netty.channel.ChannelOption;
 import reactor.core.publisher.Mono;
 
 @ExtendWith(MockitoExtension.class)

--- a/dept44-starter-webclient/src/test/java/se/sundsvall/dept44/configuration/webclient/WebClientTest.java
+++ b/dept44-starter-webclient/src/test/java/se/sundsvall/dept44/configuration/webclient/WebClientTest.java
@@ -9,6 +9,9 @@ import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.zalando.logbook.LogbookCreator.builder;
 
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,10 +19,6 @@ import org.mockito.Spy;
 import org.zalando.logbook.HttpRequest;
 import org.zalando.logbook.Logbook;
 import org.zalando.logbook.Strategy;
-
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.RecordedRequest;
 
 class WebClientTest {
 

--- a/dept44-starter-webservicetemplate/src/main/java/se/sundsvall/dept44/configuration/webservicetemplate/WebServiceTemplateBuilder.java
+++ b/dept44-starter-webservicetemplate/src/main/java/se/sundsvall/dept44/configuration/webservicetemplate/WebServiceTemplateBuilder.java
@@ -7,15 +7,17 @@ import static se.sundsvall.dept44.util.KeyStoreUtils.loadKeyStore;
 import static se.sundsvall.dept44.util.ResourceUtils.requireNonNull;
 import static se.sundsvall.dept44.util.ResourceUtils.requireNotBlank;
 
+import jakarta.xml.soap.MessageFactory;
+import jakarta.xml.soap.SOAPConstants;
+import jakarta.xml.soap.SOAPException;
+import jakarta.xml.soap.SOAPMessage;
 import java.security.KeyStore;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
 import javax.net.ssl.SSLContext;
-
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
 import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.config.ConnectionConfig;
@@ -36,11 +38,6 @@ import org.springframework.ws.transport.http.HttpComponents5MessageSender;
 import org.zalando.logbook.Logbook;
 import org.zalando.logbook.httpclient5.LogbookHttpRequestInterceptor;
 import org.zalando.logbook.httpclient5.LogbookHttpResponseInterceptor;
-
-import jakarta.xml.soap.MessageFactory;
-import jakarta.xml.soap.SOAPConstants;
-import jakarta.xml.soap.SOAPException;
-import jakarta.xml.soap.SOAPMessage;
 import se.sundsvall.dept44.configuration.Constants;
 import se.sundsvall.dept44.configuration.webservicetemplate.exception.WebServiceTemplateException;
 import se.sundsvall.dept44.configuration.webservicetemplate.interceptor.DefaultFaultInterceptor;

--- a/dept44-starter-webservicetemplate/src/main/java/se/sundsvall/dept44/configuration/webservicetemplate/interceptor/DefaultFaultInterceptor.java
+++ b/dept44-starter-webservicetemplate/src/main/java/se/sundsvall/dept44/configuration/webservicetemplate/interceptor/DefaultFaultInterceptor.java
@@ -3,7 +3,6 @@ package se.sundsvall.dept44.configuration.webservicetemplate.interceptor;
 import static org.zalando.problem.Status.INTERNAL_SERVER_ERROR;
 
 import java.util.Optional;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ws.client.WebServiceClientException;

--- a/dept44-starter-webservicetemplate/src/main/java/se/sundsvall/dept44/configuration/webservicetemplate/interceptor/RequestIdInterceptor.java
+++ b/dept44-starter-webservicetemplate/src/main/java/se/sundsvall/dept44/configuration/webservicetemplate/interceptor/RequestIdInterceptor.java
@@ -4,7 +4,6 @@ import org.apache.hc.core5.http.EntityDetails;
 import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpRequestInterceptor;
 import org.apache.hc.core5.http.protocol.HttpContext;
-
 import se.sundsvall.dept44.requestid.RequestId;
 
 public class RequestIdInterceptor implements HttpRequestInterceptor {

--- a/dept44-starter-webservicetemplate/src/test/java/se/sundsvall/dept44/configuration/webservicetemplate/WebServiceTemplateBuilderTest.java
+++ b/dept44-starter-webservicetemplate/src/test/java/se/sundsvall/dept44/configuration/webservicetemplate/WebServiceTemplateBuilderTest.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import java.util.Set;
-
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,7 +20,6 @@ import org.springframework.ws.client.core.WebServiceTemplate;
 import org.springframework.ws.client.support.interceptor.ClientInterceptor;
 import org.springframework.ws.transport.http.HttpComponents5ClientFactory;
 import org.zalando.logbook.Logbook;
-
 import se.sundsvall.dept44.configuration.webservicetemplate.exception.WebServiceTemplateException;
 import se.sundsvall.dept44.configuration.webservicetemplate.interceptor.DefaultFaultInterceptor;
 import se.sundsvall.dept44.support.BasicAuthentication;

--- a/dept44-starter-webservicetemplate/src/test/java/se/sundsvall/dept44/configuration/webservicetemplate/exception/WebServiceTemplateExceptionTest.java
+++ b/dept44-starter-webservicetemplate/src/test/java/se/sundsvall/dept44/configuration/webservicetemplate/exception/WebServiceTemplateExceptionTest.java
@@ -1,8 +1,8 @@
 package se.sundsvall.dept44.configuration.webservicetemplate.exception;
 
-import org.junit.jupiter.api.Test;
-
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import org.junit.jupiter.api.Test;
 
 class WebServiceTemplateExceptionTest {
 

--- a/dept44-starter-webservicetemplate/src/test/java/se/sundsvall/dept44/configuration/webservicetemplate/interceptor/RequestIdInterceptorTest.java
+++ b/dept44-starter-webservicetemplate/src/test/java/se/sundsvall/dept44/configuration/webservicetemplate/interceptor/RequestIdInterceptorTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import se.sundsvall.dept44.requestid.RequestId;
 
 @ExtendWith(MockitoExtension.class)

--- a/dept44-starter/src/main/java/se/sundsvall/dept44/ServiceApplication.java
+++ b/dept44-starter/src/main/java/se/sundsvall/dept44/ServiceApplication.java
@@ -4,7 +4,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurationExcludeFilter;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;

--- a/dept44-starter/src/main/java/se/sundsvall/dept44/configuration/BodyFilterProperties.java
+++ b/dept44-starter/src/main/java/se/sundsvall/dept44/configuration/BodyFilterProperties.java
@@ -2,7 +2,6 @@ package se.sundsvall.dept44.configuration;
 
 import java.util.List;
 import java.util.Map;
-
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 

--- a/dept44-starter/src/main/java/se/sundsvall/dept44/configuration/DefaultCircuitBreakerPropertiesConfiguration.java
+++ b/dept44-starter/src/main/java/se/sundsvall/dept44/configuration/DefaultCircuitBreakerPropertiesConfiguration.java
@@ -1,12 +1,10 @@
 package se.sundsvall.dept44.configuration;
 
+import io.github.resilience4j.springboot3.circuitbreaker.autoconfigure.CircuitBreakerProperties;
 import java.util.Objects;
-
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.context.annotation.Configuration;
-
-import io.github.resilience4j.springboot3.circuitbreaker.autoconfigure.CircuitBreakerProperties;
 
 /**
  * The purpose with this class is to set circuitbreaker baseConfig to "default"

--- a/dept44-starter/src/main/java/se/sundsvall/dept44/configuration/HealthConfiguration.java
+++ b/dept44-starter/src/main/java/se/sundsvall/dept44/configuration/HealthConfiguration.java
@@ -6,7 +6,6 @@ import static org.springframework.boot.actuate.health.Status.UNKNOWN;
 import static org.springframework.boot.actuate.health.Status.UP;
 
 import java.util.Set;
-
 import org.springframework.boot.actuate.health.Status;
 import org.springframework.boot.actuate.health.StatusAggregator;
 import org.springframework.context.annotation.Bean;

--- a/dept44-starter/src/main/java/se/sundsvall/dept44/configuration/LogbookConfiguration.java
+++ b/dept44-starter/src/main/java/se/sundsvall/dept44/configuration/LogbookConfiguration.java
@@ -8,6 +8,7 @@ import static se.sundsvall.dept44.logbook.filter.ResponseFilterDefinition.binary
 import static se.sundsvall.dept44.logbook.filter.ResponseFilterDefinition.fileAttachmentFilter;
 import static se.sundsvall.dept44.util.EncodingUtils.fixDoubleEncodedUTF8Content;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -17,7 +18,6 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -36,8 +36,6 @@ import org.zalando.logbook.autoconfigure.LogbookAutoConfiguration;
 import org.zalando.logbook.core.Conditions;
 import org.zalando.logbook.core.DefaultSink;
 import org.zalando.logbook.json.JsonHttpLogFormatter;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Configuration
 @AutoConfigureBefore(LogbookAutoConfiguration.class)

--- a/dept44-starter/src/main/java/se/sundsvall/dept44/configuration/ObjectMapperConfiguration.java
+++ b/dept44-starter/src/main/java/se/sundsvall/dept44/configuration/ObjectMapperConfiguration.java
@@ -1,14 +1,12 @@
 package se.sundsvall.dept44.configuration;
 
-import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-
 import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
-
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import se.sundsvall.dept44.util.jacoco.ExcludeFromJacocoGeneratedCoverageReport;
 
 @Configuration

--- a/dept44-starter/src/main/java/se/sundsvall/dept44/configuration/OpenApiConfiguration.java
+++ b/dept44-starter/src/main/java/se/sundsvall/dept44/configuration/OpenApiConfiguration.java
@@ -1,18 +1,5 @@
 package se.sundsvall.dept44.configuration;
 
-import java.util.Collections;
-import java.util.Optional;
-
-import org.springdoc.core.customizers.OpenApiCustomizer;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
@@ -23,6 +10,17 @@ import io.swagger.v3.oas.models.security.OAuthFlow;
 import io.swagger.v3.oas.models.security.OAuthFlows;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
+import java.util.Collections;
+import java.util.Optional;
+import org.springdoc.core.customizers.OpenApiCustomizer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @ConditionalOnProperty(name = "openapi.enabled", havingValue = "true", matchIfMissing = true)

--- a/dept44-starter/src/main/java/se/sundsvall/dept44/configuration/OpenApiProperties.java
+++ b/dept44-starter/src/main/java/se/sundsvall/dept44/configuration/OpenApiProperties.java
@@ -1,13 +1,11 @@
 package se.sundsvall.dept44.configuration;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
-
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 

--- a/dept44-starter/src/main/java/se/sundsvall/dept44/configuration/TruststoreConfiguration.java
+++ b/dept44-starter/src/main/java/se/sundsvall/dept44/configuration/TruststoreConfiguration.java
@@ -6,7 +6,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Scope;
-
 import se.sundsvall.dept44.security.Truststore;
 
 @Configuration

--- a/dept44-starter/src/main/java/se/sundsvall/dept44/configuration/WebConfiguration.java
+++ b/dept44-starter/src/main/java/se/sundsvall/dept44/configuration/WebConfiguration.java
@@ -10,19 +10,18 @@ import static org.zalando.problem.Status.NOT_IMPLEMENTED;
 import static se.sundsvall.dept44.configuration.Constants.APPLICATION_YAML;
 import static se.sundsvall.dept44.configuration.Constants.APPLICATION_YML;
 
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.util.List;
-import java.util.Locale;
-
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Locale;
 import org.slf4j.MDC;
 import org.springdoc.webmvc.api.OpenApiWebMvcResource;
 import org.springframework.beans.factory.annotation.Value;
@@ -45,11 +44,8 @@ import org.springframework.web.servlet.config.annotation.ContentNegotiationConfi
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.zalando.problem.Problem;
-
 import se.sundsvall.dept44.requestid.RequestId;
 import se.sundsvall.dept44.util.ResourceUtils;
-
-import io.swagger.v3.oas.annotations.Operation;
 
 @Configuration
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)

--- a/dept44-starter/src/main/java/se/sundsvall/dept44/configuration/WebFluxConfiguration.java
+++ b/dept44-starter/src/main/java/se/sundsvall/dept44/configuration/WebFluxConfiguration.java
@@ -8,7 +8,6 @@ import org.springframework.web.reactive.config.WebFluxConfigurer;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.WebFilter;
 import org.springframework.web.server.WebFilterChain;
-
 import reactor.core.publisher.Mono;
 import se.sundsvall.dept44.requestid.RequestId;
 

--- a/dept44-starter/src/main/java/se/sundsvall/dept44/logbook/filter/BodyFilterProvider.java
+++ b/dept44-starter/src/main/java/se/sundsvall/dept44/logbook/filter/BodyFilterProvider.java
@@ -10,6 +10,12 @@ import static org.zalando.logbook.BodyFilter.merge;
 import static org.zalando.logbook.core.BodyFilters.defaultValue;
 import static org.zalando.logbook.json.JsonBodyFilters.replaceJsonStringProperty;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 import java.io.ByteArrayInputStream;
 import java.io.StringWriter;
 import java.nio.charset.Charset;
@@ -17,7 +23,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -31,20 +36,12 @@ import javax.xml.transform.stream.StreamResult;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathFactory;
-
 import org.apache.hc.core5.http.ContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 import org.zalando.logbook.BodyFilter;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.jayway.jsonpath.Configuration;
-import com.jayway.jsonpath.JsonPath;
-import com.jayway.jsonpath.Option;
-import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
-import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 
 public final class BodyFilterProvider {
 

--- a/dept44-starter/src/main/java/se/sundsvall/dept44/logbook/filter/ResponseFilterDefinition.java
+++ b/dept44-starter/src/main/java/se/sundsvall/dept44/logbook/filter/ResponseFilterDefinition.java
@@ -7,7 +7,6 @@ import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import static org.zalando.logbook.core.ResponseFilters.replaceBody;
 
 import java.util.List;
-
 import org.springframework.http.MediaType;
 import org.zalando.logbook.ResponseFilter;
 

--- a/dept44-starter/src/main/java/se/sundsvall/dept44/requestid/RequestId.java
+++ b/dept44-starter/src/main/java/se/sundsvall/dept44/requestid/RequestId.java
@@ -5,7 +5,6 @@ import static java.util.Objects.nonNull;
 import static org.apache.commons.lang3.math.NumberUtils.INTEGER_ZERO;
 
 import java.util.UUID;
-
 import org.slf4j.MDC;
 
 public final class RequestId {

--- a/dept44-starter/src/main/java/se/sundsvall/dept44/security/Truststore.java
+++ b/dept44-starter/src/main/java/se/sundsvall/dept44/security/Truststore.java
@@ -19,10 +19,8 @@ import java.security.cert.X509Certificate;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Stream;
-
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.Resource;

--- a/dept44-starter/src/main/java/se/sundsvall/dept44/util/EncodingUtils.java
+++ b/dept44-starter/src/main/java/se/sundsvall/dept44/util/EncodingUtils.java
@@ -10,7 +10,8 @@ public final class EncodingUtils {
 	/**
 	 * Removes double encoded content.
 	 *
-	 * If a String contains characters like: "ÃÃÃÃ¥Ã¤Ã¶", it might be double encoded.
+	 * If a String contains characters like: "Ã
+	 * ÃÃÃ¥Ã¤Ã¶", it might be double encoded.
 	 * By running it through this method, it will become correctly UTF-8 encoded again.
 	 *
 	 * @param  string String to fix
@@ -27,7 +28,8 @@ public final class EncodingUtils {
 	/**
 	 * Check if a string contains double encoded UTF-8 content.
 	 *
-	 * If a String contains characters like: "ÃÃÃÃ¥Ã¤Ã¶", it might be double encoded.
+	 * If a String contains characters like: "Ã
+	 * ÃÃÃ¥Ã¤Ã¶", it might be double encoded.
 	 * This method will detect that.
 	 *
 	 * @param  string content to check

--- a/dept44-starter/src/main/java/se/sundsvall/dept44/util/KeyStoreUtils.java
+++ b/dept44-starter/src/main/java/se/sundsvall/dept44/util/KeyStoreUtils.java
@@ -2,7 +2,6 @@ package se.sundsvall.dept44.util;
 
 import java.io.ByteArrayInputStream;
 import java.security.KeyStore;
-
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;

--- a/dept44-starter/src/main/java/se/sundsvall/dept44/util/MunicipalityUtils.java
+++ b/dept44-starter/src/main/java/se/sundsvall/dept44/util/MunicipalityUtils.java
@@ -4,15 +4,13 @@ import static java.util.Comparator.comparing;
 import static org.apache.commons.lang3.StringUtils.upperCase;
 import static org.springframework.util.ResourceUtils.getURL;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 
 public final class MunicipalityUtils {
 

--- a/dept44-starter/src/main/java/se/sundsvall/dept44/util/ResourceUtils.java
+++ b/dept44-starter/src/main/java/se/sundsvall/dept44/util/ResourceUtils.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
 import java.nio.charset.Charset;
-
 import org.springframework.core.io.Resource;
 
 public final class ResourceUtils {

--- a/dept44-starter/src/test/java/se/sundsvall/dept44/CertificateTest.java
+++ b/dept44-starter/src/test/java/se/sundsvall/dept44/CertificateTest.java
@@ -10,7 +10,6 @@ import java.security.cert.X509Certificate;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.stream.Stream;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;

--- a/dept44-starter/src/test/java/se/sundsvall/dept44/configuration/BodyFilterPropertiesTest.java
+++ b/dept44-starter/src/test/java/se/sundsvall/dept44/configuration/BodyFilterPropertiesTest.java
@@ -3,7 +3,6 @@ package se.sundsvall.dept44.configuration;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
-
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/dept44-starter/src/test/java/se/sundsvall/dept44/configuration/DefaultCircuitBreakerPropertiesConfigurationTest.java
+++ b/dept44-starter/src/test/java/se/sundsvall/dept44/configuration/DefaultCircuitBreakerPropertiesConfigurationTest.java
@@ -3,16 +3,14 @@ package se.sundsvall.dept44.configuration;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.github.resilience4j.common.circuitbreaker.configuration.CommonCircuitBreakerConfigurationProperties.InstanceProperties;
+import io.github.resilience4j.springboot3.circuitbreaker.autoconfigure.CircuitBreakerProperties;
 import java.util.Map;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import io.github.resilience4j.springboot3.circuitbreaker.autoconfigure.CircuitBreakerProperties;
-import io.github.resilience4j.common.circuitbreaker.configuration.CommonCircuitBreakerConfigurationProperties.InstanceProperties;
 
 @ExtendWith(MockitoExtension.class)
 class DefaultCircuitBreakerPropertiesConfigurationTest {

--- a/dept44-starter/src/test/java/se/sundsvall/dept44/configuration/HealthConfigurationTest.java
+++ b/dept44-starter/src/test/java/se/sundsvall/dept44/configuration/HealthConfigurationTest.java
@@ -11,7 +11,6 @@ import static se.sundsvall.dept44.configuration.HealthConfiguration.RESTRICTED;
 
 import java.util.Set;
 import java.util.stream.Stream;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;

--- a/dept44-starter/src/test/java/se/sundsvall/dept44/configuration/ObjectMapperConfigurationTest.java
+++ b/dept44-starter/src/test/java/se/sundsvall/dept44/configuration/ObjectMapperConfigurationTest.java
@@ -2,14 +2,13 @@ package se.sundsvall.dept44.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
 import org.springframework.boot.test.context.SpringBootTest;
-
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 
 @SpringBootTest(classes = ObjectMapperConfiguration.class)
 class ObjectMapperConfigurationTest {

--- a/dept44-starter/src/test/java/se/sundsvall/dept44/configuration/OpenApiConfigurationTest.java
+++ b/dept44-starter/src/test/java/se/sundsvall/dept44/configuration/OpenApiConfigurationTest.java
@@ -3,16 +3,14 @@ package se.sundsvall.dept44.configuration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import java.util.Map;
-
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-
-import io.swagger.v3.oas.models.Operation;
-import io.swagger.v3.oas.models.security.SecurityScheme;
 
 @SpringBootTest(classes = OpenApiConfiguration.class)
 @ActiveProfiles("junit")

--- a/dept44-starter/src/test/java/se/sundsvall/dept44/configuration/TruststoreConfigurationTest.java
+++ b/dept44-starter/src/test/java/se/sundsvall/dept44/configuration/TruststoreConfigurationTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-
 import se.sundsvall.dept44.security.Truststore;
 
 @SpringBootTest(classes = TruststoreConfiguration.class)

--- a/dept44-starter/src/test/java/se/sundsvall/dept44/configuration/WebConfigurationTest.java
+++ b/dept44-starter/src/test/java/se/sundsvall/dept44/configuration/WebConfigurationTest.java
@@ -10,17 +10,15 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Stream;
-
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -43,7 +41,6 @@ import org.springframework.web.servlet.config.annotation.ContentNegotiationConfi
 import org.springframework.web.servlet.config.annotation.InterceptorRegistration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.zalando.problem.ThrowableProblem;
-
 import se.sundsvall.dept44.requestid.RequestId;
 
 class WebConfigurationTest {

--- a/dept44-starter/src/test/java/se/sundsvall/dept44/configuration/WebFluxConfigurationTest.java
+++ b/dept44-starter/src/test/java/se/sundsvall/dept44/configuration/WebFluxConfigurationTest.java
@@ -18,7 +18,6 @@ import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.WebFilterChain;
-
 import reactor.core.publisher.Mono;
 import se.sundsvall.dept44.requestid.RequestId;
 

--- a/dept44-starter/src/test/java/se/sundsvall/dept44/exception/ClientProblemTest.java
+++ b/dept44-starter/src/test/java/se/sundsvall/dept44/exception/ClientProblemTest.java
@@ -5,7 +5,6 @@ import static org.zalando.problem.Status.BAD_REQUEST;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-
 import org.junit.jupiter.api.Test;
 import org.zalando.problem.AbstractThrowableProblem;
 import org.zalando.problem.Status;

--- a/dept44-starter/src/test/java/se/sundsvall/dept44/exception/ServerProblemTest.java
+++ b/dept44-starter/src/test/java/se/sundsvall/dept44/exception/ServerProblemTest.java
@@ -5,7 +5,6 @@ import static org.zalando.problem.Status.BAD_GATEWAY;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-
 import org.junit.jupiter.api.Test;
 import org.zalando.problem.AbstractThrowableProblem;
 import org.zalando.problem.Status;

--- a/dept44-starter/src/test/java/se/sundsvall/dept44/logbook/filter/BodyFilterProviderTest.java
+++ b/dept44-starter/src/test/java/se/sundsvall/dept44/logbook/filter/BodyFilterProviderTest.java
@@ -13,9 +13,9 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Map;
 import java.util.stream.Stream;
-
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -23,7 +23,6 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerFactory;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -35,9 +34,6 @@ import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.zalando.logbook.BodyFilter;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import se.sundsvall.dept44.test.annotation.resource.Load;
 import se.sundsvall.dept44.test.extension.ResourceLoaderExtension;
 

--- a/dept44-starter/src/test/java/se/sundsvall/dept44/logbook/filter/ResponseFilterDefinitionTest.java
+++ b/dept44-starter/src/test/java/se/sundsvall/dept44/logbook/filter/ResponseFilterDefinitionTest.java
@@ -21,7 +21,6 @@ import static se.sundsvall.dept44.logbook.filter.ResponseFilterDefinition.fileAt
 
 import java.io.IOException;
 import java.util.Arrays;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;

--- a/dept44-starter/src/test/java/se/sundsvall/dept44/security/TruststoreTest.java
+++ b/dept44-starter/src/test/java/se/sundsvall/dept44/security/TruststoreTest.java
@@ -6,9 +6,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
-
 import javax.net.ssl.SSLContext;
-
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedConstruction;
 import org.mockito.Mockito;

--- a/dept44-starter/src/test/java/se/sundsvall/dept44/support/BasicAuthenticationTest.java
+++ b/dept44-starter/src/test/java/se/sundsvall/dept44/support/BasicAuthenticationTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.stream.Stream;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;

--- a/dept44-starter/src/test/java/se/sundsvall/dept44/util/DateUtilsTest.java
+++ b/dept44-starter/src/test/java/se/sundsvall/dept44/util/DateUtilsTest.java
@@ -1,10 +1,7 @@
 package se.sundsvall.dept44.util;
 
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -16,9 +13,11 @@ import java.time.chrono.ThaiBuddhistDate;
 import java.time.temporal.Temporal;
 import java.util.TimeZone;
 import java.util.stream.Stream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class DateUtilsTest {
 

--- a/dept44-starter/src/test/java/se/sundsvall/dept44/util/EncodingUtilsTest.java
+++ b/dept44-starter/src/test/java/se/sundsvall/dept44/util/EncodingUtilsTest.java
@@ -3,24 +3,11 @@ package se.sundsvall.dept44.util;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.stream.Stream;
-
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class EncodingUtilsTest {
-
-	@ParameterizedTest
-	@MethodSource("isDoubleEncodedUTF8ContentArguments")
-	void isDoubleEncodedUTF8Content(String stringToCheck, boolean isDoubleEncoded) {
-		assertThat(EncodingUtils.isDoubleEncodedUTF8Content(stringToCheck)).isEqualTo(isDoubleEncoded);
-	}
-
-	@ParameterizedTest
-	@MethodSource("fixDoubleEncodedUTF8ContentArguments")
-	void fixDoubleEncodedUTF8Content(String doubleEncodedString, String fixedString) {
-		assertThat(EncodingUtils.fixDoubleEncodedUTF8Content(doubleEncodedString)).isEqualTo(fixedString);
-	}
 
 	private static Stream<Arguments> isDoubleEncodedUTF8ContentArguments() {
 		return Stream.of(
@@ -31,7 +18,9 @@ class EncodingUtilsTest {
 			Arguments.of("LÃ¶pande underhÃ¥ll", true),
 			Arguments.of("Uppdatering/fÃ¶rÃ¤ndring", true),
 			Arguments.of("VÃ¤xelfÃ¶rÃ¤ndring", true),
+			// spotless:off
 			Arguments.of("ÃÃÃÃ¥Ã¤Ã¶", true),
+			//spotless:on
 			Arguments.of("Användarhantering", false),
 			Arguments.of("Ändring", false),
 			Arguments.of("Avbeställning", false),
@@ -51,6 +40,20 @@ class EncodingUtilsTest {
 			Arguments.of("LÃ¶pande underhÃ¥ll", "Löpande underhåll"),
 			Arguments.of("Uppdatering/fÃ¶rÃ¤ndring", "Uppdatering/förändring"),
 			Arguments.of("VÃ¤xelfÃ¶rÃ¤ndring", "Växelförändring"),
+			// spotless:off
 			Arguments.of("ÃÃÃÃ¥Ã¤Ã¶", "ÅÄÖåäö"));
+	}//spotless:on
+
+	@ParameterizedTest
+	@MethodSource("isDoubleEncodedUTF8ContentArguments")
+	void isDoubleEncodedUTF8Content(final String stringToCheck, final boolean isDoubleEncoded) {
+		assertThat(EncodingUtils.isDoubleEncodedUTF8Content(stringToCheck)).isEqualTo(isDoubleEncoded);
 	}
+
+	@ParameterizedTest
+	@MethodSource("fixDoubleEncodedUTF8ContentArguments")
+	void fixDoubleEncodedUTF8Content(final String doubleEncodedString, final String fixedString) {
+		assertThat(EncodingUtils.fixDoubleEncodedUTF8Content(doubleEncodedString)).isEqualTo(fixedString);
+	}
+
 }

--- a/dept44-starter/src/test/java/se/sundsvall/dept44/util/KeyStoreUtilsTest.java
+++ b/dept44-starter/src/test/java/se/sundsvall/dept44/util/KeyStoreUtilsTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.io.IOException;
-
 import org.junit.jupiter.api.Test;
 import org.springframework.core.io.ClassPathResource;
 

--- a/dept44-starter/src/test/java/se/sundsvall/dept44/util/MunicipalityUtilsTest.java
+++ b/dept44-starter/src/test/java/se/sundsvall/dept44/util/MunicipalityUtilsTest.java
@@ -7,14 +7,11 @@ import static org.apache.commons.lang3.math.NumberUtils.isDigits;
 import static org.assertj.core.api.Assertions.assertThat;
 import static se.sundsvall.dept44.test.annotation.resource.Load.ResourceType.STRING;
 
-import java.util.List;
-
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
-
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import se.sundsvall.dept44.test.annotation.resource.Load;
 import se.sundsvall.dept44.test.extension.ResourceLoaderExtension;
 import se.sundsvall.dept44.util.MunicipalityUtils.Municipality;

--- a/dept44-starter/src/test/java/se/sundsvall/dept44/util/ResourceUtilsTest.java
+++ b/dept44-starter/src/test/java/se/sundsvall/dept44/util/ResourceUtilsTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.UncheckedIOException;
-
 import org.junit.jupiter.api.Test;
 import org.springframework.core.io.ClassPathResource;
 


### PR DESCRIPTION
This handles imports order and removes unused imports. 

The import order is not configured but using the spotless default values. I ask you for feedback if this is "good enough" or if we want to modify it somewhat. Personally I could not care less about the order so I have no opinion.

Here are the configuration options for importOrder

```
    <importOrder>  <!-- or a custom ordering -->
      <wildcardsLast>false</wildcardsLast> <!-- Optional, default false. Sort wildcard import after specific imports -->
      <order>java|javax,org,com,com.diffplug,,\#com.diffplug,\#</order>  <!-- or use <file>${project.basedir}/eclipse.importorder</file> -->
      <!-- you can use an empty string for all the imports you didn't specify explicitly, '|' to join group without blank line, and '\#` prefix for static imports. -->
      <semanticSort>false</semanticSort> <!-- Optional, default false. Sort by package, then class, then member (for static imports). Splitting is based on common conventions (packages are lower case, classes start with upper case). Use <treatAsPackage> and <treatAsClass> for exceptions. -->
      <treatAsPackage> <!-- Packages starting with upper case letters. -->
        <package>com.example.MyPackage</package>
      </treatAsPackage>
      <treatAsClass> <!-- Classes starting with lower case letters. -->
        <class>com.example.myClass</class>
      </treatAsClass>
    </importOrder>
```
Let me know what you think

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix
- [x] New feature
- [ ] Removed feature
- [x] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).