### PR TITLE
UF-11547: Set generation for springdoc to 3.0.1

### DIFF
--- a/dept44-example/src/integration-test/resources/EndpointsIT/__files/test01_apiDocs/response.json
+++ b/dept44-example/src/integration-test/resources/EndpointsIT/__files/test01_apiDocs/response.json
@@ -1,602 +1,63 @@
 {
-	"components": {
-		"schemas": {
-			"Violation": {
-				"type": "object",
-				"properties": {
-					"field": {
-						"type": "string"
-					},
-					"message": {
-						"type": "string"
-					}
-				}
-			},
-			"PetImage": {
-				"description": "Pet image model",
-				"type": "object",
-				"properties": {
-					"fileName": {
-						"description": "File name",
-						"type": "string",
-						"example": "image.jpg"
-					},
-					"id": {
-						"format": "int64",
-						"description": "Pet image ID",
-						"type": "integer",
-						"example": 1
-					},
-					"mimeType": {
-						"description": "Mime type",
-						"type": "string",
-						"example": "image/jpeg"
-					}
-				}
-			},
-			"PetInventoryItem": {
-				"description": "Pet inventory item model",
-				"type": "object",
-				"properties": {
-					"images": {
-						"type": "array",
-						"items": {
-							"$ref": "#/components/schemas/PetImage"
-						}
-					},
-					"price": {
-						"format": "float",
-						"description": "Pet price",
-						"type": "number",
-						"example": 1.5
-					},
-					"name": {
-						"description": "Pet name",
-						"type": "string",
-						"example": "Daisy"
-					},
-					"id": {
-						"format": "int64",
-						"description": "Pet ID",
-						"type": "integer",
-						"example": 1
-					},
-					"type": {
-						"description": "Pet type",
-						"type": "string",
-						"example": "DOG"
-					}
-				}
-			},
-			"StatusType": {
-				"type": "object",
-				"properties": {
-					"reasonPhrase": {
-						"type": "string"
-					},
-					"statusCode": {
-						"format": "int32",
-						"type": "integer"
-					}
-				}
-			},
-			"ThrowableProblem": {
-				"type": "object",
-				"properties": {
-					"instance": {
-						"format": "uri",
-						"type": "string"
-					},
-					"localizedMessage": {
-						"type": "string"
-					},
-					"cause": {
-						"$ref": "#/components/schemas/ThrowableProblem"
-					},
-					"stackTrace": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"fileName": {
-									"type": "string"
-								},
-								"moduleVersion": {
-									"type": "string"
-								},
-								"moduleName": {
-									"type": "string"
-								},
-								"nativeMethod": {
-									"type": "boolean"
-								},
-								"methodName": {
-									"type": "string"
-								},
-								"className": {
-									"type": "string"
-								},
-								"lineNumber": {
-									"format": "int32",
-									"type": "integer"
-								},
-								"classLoaderName": {
-									"type": "string"
-								}
-							}
-						}
-					},
-					"detail": {
-						"type": "string"
-					},
-					"suppressed": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"localizedMessage": {
-									"type": "string"
-								},
-								"stackTrace": {
-									"type": "array",
-									"items": {
-										"type": "object",
-										"properties": {
-											"fileName": {
-												"type": "string"
-											},
-											"moduleVersion": {
-												"type": "string"
-											},
-											"moduleName": {
-												"type": "string"
-											},
-											"nativeMethod": {
-												"type": "boolean"
-											},
-											"methodName": {
-												"type": "string"
-											},
-											"className": {
-												"type": "string"
-											},
-											"lineNumber": {
-												"format": "int32",
-												"type": "integer"
-											},
-											"classLoaderName": {
-												"type": "string"
-											}
-										}
-									}
-								},
-								"message": {
-									"type": "string"
-								}
-							}
-						}
-					},
-					"message": {
-						"type": "string"
-					},
-					"type": {
-						"format": "uri",
-						"type": "string"
-					},
-					"title": {
-						"type": "string"
-					},
-					"parameters": {
-						"additionalProperties": {},
-						"type": "object"
-					},
-					"status": {
-						"$ref": "#/components/schemas/StatusType"
-					}
-				}
-			},
-			"Problem": {
-				"type": "object",
-				"properties": {
-					"instance": {
-						"format": "uri",
-						"type": "string"
-					},
-					"detail": {
-						"type": "string"
-					},
-					"type": {
-						"format": "uri",
-						"type": "string"
-					},
-					"title": {
-						"type": "string"
-					},
-					"parameters": {
-						"additionalProperties": {},
-						"type": "object"
-					},
-					"status": {
-						"$ref": "#/components/schemas/StatusType"
-					}
-				}
-			},
-			"ConstraintViolationProblem": {
-				"type": "object",
-				"properties": {
-					"instance": {
-						"format": "uri",
-						"type": "string"
-					},
-					"localizedMessage": {
-						"type": "string"
-					},
-					"violations": {
-						"type": "array",
-						"items": {
-							"$ref": "#/components/schemas/Violation"
-						}
-					},
-					"cause": {
-						"$ref": "#/components/schemas/ThrowableProblem"
-					},
-					"stackTrace": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"fileName": {
-									"type": "string"
-								},
-								"moduleVersion": {
-									"type": "string"
-								},
-								"moduleName": {
-									"type": "string"
-								},
-								"nativeMethod": {
-									"type": "boolean"
-								},
-								"methodName": {
-									"type": "string"
-								},
-								"className": {
-									"type": "string"
-								},
-								"lineNumber": {
-									"format": "int32",
-									"type": "integer"
-								},
-								"classLoaderName": {
-									"type": "string"
-								}
-							}
-						}
-					},
-					"detail": {
-						"type": "string"
-					},
-					"suppressed": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"localizedMessage": {
-									"type": "string"
-								},
-								"stackTrace": {
-									"type": "array",
-									"items": {
-										"type": "object",
-										"properties": {
-											"fileName": {
-												"type": "string"
-											},
-											"moduleVersion": {
-												"type": "string"
-											},
-											"moduleName": {
-												"type": "string"
-											},
-											"nativeMethod": {
-												"type": "boolean"
-											},
-											"methodName": {
-												"type": "string"
-											},
-											"className": {
-												"type": "string"
-											},
-											"lineNumber": {
-												"format": "int32",
-												"type": "integer"
-											},
-											"classLoaderName": {
-												"type": "string"
-											}
-										}
-									}
-								},
-								"message": {
-									"type": "string"
-								}
-							}
-						}
-					},
-					"type": {
-						"format": "uri",
-						"type": "string"
-					},
-					"title": {
-						"type": "string"
-					},
-					"message": {
-						"type": "string"
-					},
-					"parameters": {
-						"additionalProperties": {},
-						"type": "object"
-					},
-					"status": {
-						"$ref": "#/components/schemas/StatusType"
-					}
-				}
-			}
+	"openapi": "3.0.1",
+	"info": {
+		"title": "api-service-pet-inventory",
+		"contact": {},
+		"license": {
+			"name": "MIT License",
+			"url": "https://opensource.org/licenses/MIT"
 		},
-		"securitySchemes": {}
+		"version": "6.0.6-SNAPSHOT"
 	},
 	"servers": [
 		{
-			"description": "Generated server url",
-			"url": "${json-unit.any-string}"
+			"url": "${json-unit.any-string}",
+			"description": "Generated server url"
 		}
 	],
-	"openapi": "3.1.0",
+	"tags": [
+		{
+			"name": "Pet inventory",
+			"description": "Pet inventory operations"
+		}
+	],
 	"paths": {
-		"/pet-inventory-items/{id}": {
-			"get": {
-				"summary": "Get Pet inventory item by id",
-				"operationId": "getPetInventoryItem",
-				"responses": {
-					"200": {
-						"description": "Successful operation",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/PetInventoryItem"
-								}
-							},
-							"application/problem+json": {
-								"schema": {
-									"$ref": "#/components/schemas/PetInventoryItem"
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Bad request",
-						"content": {
-							"application/problem+json": {
-								"schema": {
-									"oneOf": [
-										{
-											"$ref": "#/components/schemas/Problem"
-										},
-										{
-											"$ref": "#/components/schemas/ConstraintViolationProblem"
-										}
-									]
-								}
-							}
-						}
-					},
-					"500": {
-						"description": "Internal Server error",
-						"content": {
-							"application/problem+json": {
-								"schema": {
-									"$ref": "#/components/schemas/Problem"
-								}
-							}
-						}
-					},
-					"502": {
-						"description": "Bad Gateway",
-						"content": {
-							"application/problem+json": {
-								"schema": {
-									"$ref": "#/components/schemas/Problem"
-								}
-							}
-						}
-					}
-				},
-				"parameters": [
-					{
-						"schema": {
-							"format": "int64",
-							"type": "integer"
-						},
-						"in": "path",
-						"name": "id",
-						"required": true
-					}
-				],
-				"tags": [
-					"Pet inventory"
-				]
-			}
-		},
-		"/pet-inventory-items/{id}/images/{imageId}": {
-			"get": {
-				"summary": "Get pet inventory item image by id",
-				"operationId": "getPetImage",
-				"responses": {
-					"201": {
-						"description": "Successful operation",
-						"content": {
-							"*/*": {
-								"schema": {
-									"format": "byte",
-									"type": "string"
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Bad request",
-						"content": {
-							"application/problem+json": {
-								"schema": {
-									"oneOf": [
-										{
-											"$ref": "#/components/schemas/Problem"
-										},
-										{
-											"$ref": "#/components/schemas/ConstraintViolationProblem"
-										}
-									]
-								}
-							}
-						}
-					},
-					"500": {
-						"description": "Internal Server error",
-						"content": {
-							"application/problem+json": {
-								"schema": {
-									"$ref": "#/components/schemas/Problem"
-								}
-							}
-						}
-					},
-					"502": {
-						"description": "Bad Gateway",
-						"content": {
-							"application/problem+json": {
-								"schema": {
-									"$ref": "#/components/schemas/Problem"
-								}
-							}
-						}
-					}
-				},
-				"parameters": [
-					{
-						"schema": {
-							"format": "int64",
-							"type": "integer"
-						},
-						"in": "path",
-						"name": "id",
-						"required": true
-					},
-					{
-						"schema": {
-							"format": "int64",
-							"type": "integer"
-						},
-						"in": "path",
-						"name": "imageId",
-						"required": true
-					}
-				],
-				"tags": [
-					"Pet inventory"
-				]
-			}
-		},
-		"/pet-inventory-items": {
-			"get": {
-				"summary": "Get Pet inventory items",
-				"operationId": "getPetInventoryList",
-				"responses": {
-					"200": {
-						"description": "Successful operation",
-						"content": {
-							"application/json": {
-								"schema": {
-									"type": "array",
-									"items": {
-										"$ref": "#/components/schemas/PetInventoryItem"
-									}
-								}
-							},
-							"application/problem+json": {
-								"schema": {
-									"type": "array",
-									"items": {
-										"$ref": "#/components/schemas/PetInventoryItem"
-									}
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Bad request",
-						"content": {
-							"application/problem+json": {
-								"schema": {
-									"oneOf": [
-										{
-											"$ref": "#/components/schemas/Problem"
-										},
-										{
-											"$ref": "#/components/schemas/ConstraintViolationProblem"
-										}
-									]
-								}
-							}
-						}
-					},
-					"500": {
-						"description": "Internal Server error",
-						"content": {
-							"application/problem+json": {
-								"schema": {
-									"$ref": "#/components/schemas/Problem"
-								}
-							}
-						}
-					},
-					"502": {
-						"description": "Bad Gateway",
-						"content": {
-							"application/problem+json": {
-								"schema": {
-									"$ref": "#/components/schemas/Problem"
-								}
-							}
-						}
-					}
-				},
-				"tags": [
-					"Pet inventory"
-				]
-			}
-		},
 		"/pet-inventory-items/{id}/images": {
 			"post": {
+				"tags": [
+					"Pet inventory"
+				],
 				"summary": "Add pet inventory item image by id",
+				"operationId": "addPetImage",
+				"parameters": [
+					{
+						"name": "id",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "integer",
+							"format": "int64"
+						}
+					}
+				],
 				"requestBody": {
 					"content": {
 						"multipart/form-data": {
 							"schema": {
-								"type": "object",
 								"required": [
 									"file"
 								],
+								"type": "object",
 								"properties": {
 									"file": {
-										"format": "binary",
-										"type": "string"
+										"type": "string",
+										"format": "binary"
 									}
 								}
 							}
 						}
 					}
 				},
-				"operationId": "addPetImage",
 				"responses": {
 					"201": {
 						"description": "Successful operation"
@@ -638,27 +99,224 @@
 							}
 						}
 					}
-				},
-				"parameters": [
-					{
-						"schema": {
-							"format": "int64",
-							"type": "integer"
-						},
-						"in": "path",
-						"name": "id",
-						"required": true
-					}
-				],
+				}
+			}
+		},
+		"/pet-inventory-items": {
+			"get": {
 				"tags": [
 					"Pet inventory"
-				]
+				],
+				"summary": "Get Pet inventory items",
+				"operationId": "getPetInventoryList",
+				"responses": {
+					"200": {
+						"description": "Successful operation",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "array",
+									"items": {
+										"$ref": "#/components/schemas/PetInventoryItem"
+									}
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad request",
+						"content": {
+							"application/problem+json": {
+								"schema": {
+									"oneOf": [
+										{
+											"$ref": "#/components/schemas/Problem"
+										},
+										{
+											"$ref": "#/components/schemas/ConstraintViolationProblem"
+										}
+									]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Internal Server error",
+						"content": {
+							"application/problem+json": {
+								"schema": {
+									"$ref": "#/components/schemas/Problem"
+								}
+							}
+						}
+					},
+					"502": {
+						"description": "Bad Gateway",
+						"content": {
+							"application/problem+json": {
+								"schema": {
+									"$ref": "#/components/schemas/Problem"
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/pet-inventory-items/{id}": {
+			"get": {
+				"tags": [
+					"Pet inventory"
+				],
+				"summary": "Get Pet inventory item by id",
+				"operationId": "getPetInventoryItem",
+				"parameters": [
+					{
+						"name": "id",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "integer",
+							"format": "int64"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Successful operation",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/PetInventoryItem"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad request",
+						"content": {
+							"application/problem+json": {
+								"schema": {
+									"oneOf": [
+										{
+											"$ref": "#/components/schemas/Problem"
+										},
+										{
+											"$ref": "#/components/schemas/ConstraintViolationProblem"
+										}
+									]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Internal Server error",
+						"content": {
+							"application/problem+json": {
+								"schema": {
+									"$ref": "#/components/schemas/Problem"
+								}
+							}
+						}
+					},
+					"502": {
+						"description": "Bad Gateway",
+						"content": {
+							"application/problem+json": {
+								"schema": {
+									"$ref": "#/components/schemas/Problem"
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/pet-inventory-items/{id}/images/{imageId}": {
+			"get": {
+				"tags": [
+					"Pet inventory"
+				],
+				"summary": "Get pet inventory item image by id",
+				"operationId": "getPetImage",
+				"parameters": [
+					{
+						"name": "id",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "integer",
+							"format": "int64"
+						}
+					},
+					{
+						"name": "imageId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "integer",
+							"format": "int64"
+						}
+					}
+				],
+				"responses": {
+					"201": {
+						"description": "Successful operation",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "string",
+									"format": "byte"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad request",
+						"content": {
+							"application/problem+json": {
+								"schema": {
+									"oneOf": [
+										{
+											"$ref": "#/components/schemas/Problem"
+										},
+										{
+											"$ref": "#/components/schemas/ConstraintViolationProblem"
+										}
+									]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Internal Server error",
+						"content": {
+							"application/problem+json": {
+								"schema": {
+									"$ref": "#/components/schemas/Problem"
+								}
+							}
+						}
+					},
+					"502": {
+						"description": "Bad Gateway",
+						"content": {
+							"application/problem+json": {
+								"schema": {
+									"$ref": "#/components/schemas/Problem"
+								}
+							}
+						}
+					}
+				}
 			}
 		},
 		"/api-docs": {
 			"get": {
+				"tags": [
+					"API"
+				],
 				"summary": "OpenAPI",
-				"x-auth-type": "None",
 				"operationId": "getApiDocs",
 				"responses": {
 					"200": {
@@ -672,27 +330,362 @@
 						}
 					}
 				},
-				"x-wso2-mutual-ssl": "Optional",
+				"x-auth-type": "None",
 				"x-throttling-tier": "Unlimited",
-				"tags": [
-					"API"
-				]
+				"x-wso2-mutual-ssl": "Optional"
 			}
 		}
 	},
-	"info": {
-		"license": {
-			"name": "MIT License",
-			"url": "https://opensource.org/licenses/MIT"
+	"components": {
+		"schemas": {
+			"Problem": {
+				"type": "object",
+				"properties": {
+					"instance": {
+						"type": "string",
+						"format": "uri"
+					},
+					"type": {
+						"type": "string",
+						"format": "uri"
+					},
+					"parameters": {
+						"type": "object",
+						"additionalProperties": {
+							"type": "object"
+						}
+					},
+					"status": {
+						"$ref": "#/components/schemas/StatusType"
+					},
+					"title": {
+						"type": "string"
+					},
+					"detail": {
+						"type": "string"
+					}
+				}
+			},
+			"StatusType": {
+				"type": "object",
+				"properties": {
+					"reasonPhrase": {
+						"type": "string"
+					},
+					"statusCode": {
+						"type": "integer",
+						"format": "int32"
+					}
+				}
+			},
+			"ConstraintViolationProblem": {
+				"type": "object",
+				"properties": {
+					"cause": {
+						"$ref": "#/components/schemas/ThrowableProblem"
+					},
+					"stackTrace": {
+						"type": "array",
+						"items": {
+							"type": "object",
+							"properties": {
+								"classLoaderName": {
+									"type": "string"
+								},
+								"moduleName": {
+									"type": "string"
+								},
+								"moduleVersion": {
+									"type": "string"
+								},
+								"methodName": {
+									"type": "string"
+								},
+								"fileName": {
+									"type": "string"
+								},
+								"lineNumber": {
+									"type": "integer",
+									"format": "int32"
+								},
+								"className": {
+									"type": "string"
+								},
+								"nativeMethod": {
+									"type": "boolean"
+								}
+							}
+						}
+					},
+					"type": {
+						"type": "string",
+						"format": "uri"
+					},
+					"status": {
+						"$ref": "#/components/schemas/StatusType"
+					},
+					"violations": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/Violation"
+						}
+					},
+					"title": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					},
+					"instance": {
+						"type": "string",
+						"format": "uri"
+					},
+					"parameters": {
+						"type": "object",
+						"additionalProperties": {
+							"type": "object"
+						}
+					},
+					"detail": {
+						"type": "string"
+					},
+					"suppressed": {
+						"type": "array",
+						"items": {
+							"type": "object",
+							"properties": {
+								"stackTrace": {
+									"type": "array",
+									"items": {
+										"type": "object",
+										"properties": {
+											"classLoaderName": {
+												"type": "string"
+											},
+											"moduleName": {
+												"type": "string"
+											},
+											"moduleVersion": {
+												"type": "string"
+											},
+											"methodName": {
+												"type": "string"
+											},
+											"fileName": {
+												"type": "string"
+											},
+											"lineNumber": {
+												"type": "integer",
+												"format": "int32"
+											},
+											"className": {
+												"type": "string"
+											},
+											"nativeMethod": {
+												"type": "boolean"
+											}
+										}
+									}
+								},
+								"message": {
+									"type": "string"
+								},
+								"localizedMessage": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"localizedMessage": {
+						"type": "string"
+					}
+				}
+			},
+			"ThrowableProblem": {
+				"type": "object",
+				"properties": {
+					"cause": {
+						"$ref": "#/components/schemas/ThrowableProblem"
+					},
+					"stackTrace": {
+						"type": "array",
+						"items": {
+							"type": "object",
+							"properties": {
+								"classLoaderName": {
+									"type": "string"
+								},
+								"moduleName": {
+									"type": "string"
+								},
+								"moduleVersion": {
+									"type": "string"
+								},
+								"methodName": {
+									"type": "string"
+								},
+								"fileName": {
+									"type": "string"
+								},
+								"lineNumber": {
+									"type": "integer",
+									"format": "int32"
+								},
+								"className": {
+									"type": "string"
+								},
+								"nativeMethod": {
+									"type": "boolean"
+								}
+							}
+						}
+					},
+					"message": {
+						"type": "string"
+					},
+					"instance": {
+						"type": "string",
+						"format": "uri"
+					},
+					"type": {
+						"type": "string",
+						"format": "uri"
+					},
+					"parameters": {
+						"type": "object",
+						"additionalProperties": {
+							"type": "object"
+						}
+					},
+					"status": {
+						"$ref": "#/components/schemas/StatusType"
+					},
+					"title": {
+						"type": "string"
+					},
+					"detail": {
+						"type": "string"
+					},
+					"suppressed": {
+						"type": "array",
+						"items": {
+							"type": "object",
+							"properties": {
+								"stackTrace": {
+									"type": "array",
+									"items": {
+										"type": "object",
+										"properties": {
+											"classLoaderName": {
+												"type": "string"
+											},
+											"moduleName": {
+												"type": "string"
+											},
+											"moduleVersion": {
+												"type": "string"
+											},
+											"methodName": {
+												"type": "string"
+											},
+											"fileName": {
+												"type": "string"
+											},
+											"lineNumber": {
+												"type": "integer",
+												"format": "int32"
+											},
+											"className": {
+												"type": "string"
+											},
+											"nativeMethod": {
+												"type": "boolean"
+											}
+										}
+									}
+								},
+								"message": {
+									"type": "string"
+								},
+								"localizedMessage": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"localizedMessage": {
+						"type": "string"
+					}
+				}
+			},
+			"Violation": {
+				"type": "object",
+				"properties": {
+					"field": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					}
+				}
+			},
+			"PetImage": {
+				"type": "object",
+				"properties": {
+					"id": {
+						"type": "integer",
+						"description": "Pet image ID",
+						"format": "int64",
+						"example": 1
+					},
+					"fileName": {
+						"type": "string",
+						"description": "File name",
+						"example": "image.jpg"
+					},
+					"mimeType": {
+						"type": "string",
+						"description": "Mime type",
+						"example": "image/jpeg"
+					}
+				},
+				"description": "Pet image model"
+			},
+			"PetInventoryItem": {
+				"type": "object",
+				"properties": {
+					"id": {
+						"type": "integer",
+						"description": "Pet ID",
+						"format": "int64",
+						"example": 1
+					},
+					"price": {
+						"type": "number",
+						"description": "Pet price",
+						"format": "float",
+						"example": 1.5
+					},
+					"name": {
+						"type": "string",
+						"description": "Pet name",
+						"example": "Daisy"
+					},
+					"type": {
+						"type": "string",
+						"description": "Pet type",
+						"example": "DOG"
+					},
+					"images": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/PetImage"
+						}
+					}
+				},
+				"description": "Pet inventory item model"
+			}
 		},
-		"contact": {},
-		"title": "api-service-pet-inventory",
-		"version": "${json-unit.any-string}"
-	},
-	"tags": [
-		{
-			"name": "Pet inventory",
-			"description": "Pet inventory operations"
-		}
-	]
+		"securitySchemes": {}
+	}
 }

--- a/dept44-example/src/main/java/se/sundsvall/petinventory/api/PetInventoryResource.java
+++ b/dept44-example/src/main/java/se/sundsvall/petinventory/api/PetInventoryResource.java
@@ -45,9 +45,7 @@ class PetInventoryResource {
 		this.petInventoryService = petInventoryService;
 	}
 
-	@GetMapping(produces = {
-		APPLICATION_JSON_VALUE, APPLICATION_PROBLEM_JSON_VALUE
-	})
+	@GetMapping(produces = APPLICATION_JSON_VALUE)
 	@Operation(summary = "Get Pet inventory items", responses = {
 		@ApiResponse(responseCode = "200", description = "Successful operation", useReturnTypeSchema = true),
 		@ApiResponse(responseCode = "400", description = "Bad request", content = @Content(mediaType = APPLICATION_PROBLEM_JSON_VALUE, schema = @Schema(oneOf = {
@@ -60,9 +58,7 @@ class PetInventoryResource {
 		return ok(petInventoryService.getPetInventoryList());
 	}
 
-	@GetMapping(path = "/{id}", produces = {
-		APPLICATION_JSON_VALUE, APPLICATION_PROBLEM_JSON_VALUE
-	})
+	@GetMapping(path = "/{id}", produces = APPLICATION_JSON_VALUE)
 	@Operation(summary = "Get Pet inventory item by id", responses = {
 		@ApiResponse(responseCode = "200", description = "Successful operation", useReturnTypeSchema = true),
 		@ApiResponse(responseCode = "400", description = "Bad request", content = @Content(mediaType = APPLICATION_PROBLEM_JSON_VALUE, schema = @Schema(oneOf = {
@@ -77,9 +73,7 @@ class PetInventoryResource {
 
 	@PostMapping(path = "/{id}/images", consumes = {
 		MULTIPART_FORM_DATA_VALUE
-	}, produces = {
-		APPLICATION_JSON_VALUE, APPLICATION_PROBLEM_JSON_VALUE
-	})
+	}, produces = APPLICATION_JSON_VALUE)
 	@Operation(summary = "Add pet inventory item image by id", responses = {
 		@ApiResponse(responseCode = "201", description = "Successful operation", useReturnTypeSchema = true),
 		@ApiResponse(responseCode = "400", description = "Bad request", content = @Content(mediaType = APPLICATION_PROBLEM_JSON_VALUE, schema = @Schema(oneOf = {

--- a/dept44-starter/src/main/resources/config/application.properties
+++ b/dept44-starter/src/main/resources/config/application.properties
@@ -1,28 +1,23 @@
 # Graceful shutdown
 server.shutdown=graceful
-
 # Use custom banner
 spring.banner.location=classpath:dept44-banner.txt
-
 # Disable Spring security user-details auto-configuration
 spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration,org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfiguration,org.zalando.problem.spring.web.autoconfigure.security.ProblemSecurityAutoConfiguration
-
 # Problem configuration
 spring.web.resources.add-mappings=false
 spring.mvc.throw-exception-if-no-handler-found=true
-
 # SpringDoc
 springdoc.api-docs.enabled=${openapi.enabled:true}
 springdoc.api-docs.path=/api-docs
 springdoc.swagger-ui.url=${springdoc.api-docs.path}
 springdoc.swagger-ui.tags-sorter=alpha
-
+springdoc.api-docs.version=openapi_3_0
 # Logging
 logging.file.path=log
 logging.level.se.sundsvall.dept44.payload=TRACE
 logbook.default.logger.name=se.sundsvall.dept44.payload
 logbook.default.excluded.paths=/,**/webjars/**,**${springdoc.api-docs.path}**,**/swagger-resources,**/swagger-resources/**,**/error,**/csrf,**/swagger-ui.html,**/swagger-ui/**,**/favicon.ico,**/actuator,**/actuator/**,**/h2-console/**
-
 # Jackson
 spring.jackson.default-property-inclusion=NON_NULL
 spring.jackson.serialization.fail-on-empty-beans=false
@@ -32,10 +27,8 @@ spring.jackson.deserialization.adjust-dates-to-context-time-zone=false
 spring.jackson.deserialization.fail-on-ignored-properties=false
 spring.jackson.deserialization.fail-on-unknown-properties=false
 spring.jackson.deserialization.fail-on-null-for-primitives=false
-
 # Enable spring to read properties from local .env file
 spring.config.import=optional:file:.env[.properties]
-
 # Management endpoints
 management.endpoints.web.exposure.include=*
 management.endpoints.web.exposure.exclude=heapdump,threaddump,shutdown
@@ -43,11 +36,9 @@ management.endpoint.health.show-details=always
 management.health.circuitbreakers.enabled=true
 management.info.env.enabled=true
 management.info.git.mode=full
-
 # x-forwarded header strategy
 server.forward-headers-strategy=framework
-
-# Resilience4j default values. 
+# Resilience4j default values.
 # Used for circuit-breaking and health-indicator functionality. See documentation: https://resilience4j.readme.io/docs/circuitbreaker
 resilience4j.circuitbreaker.configs.default.minimumNumberOfCalls=5
 resilience4j.circuitbreaker.configs.default.failureRateThreshold=50
@@ -58,6 +49,5 @@ resilience4j.circuitbreaker.configs.default.eventConsumerBufferSize=50
 resilience4j.circuitbreaker.configs.default.automaticTransitionFromOpenToHalfOpenEnabled=false
 resilience4j.circuitbreaker.configs.default.registerHealthIndicator=true
 resilience4j.circuitbreaker.configs.default.allowHealthIndicatorToFail=false
-
 # Default connection-timeout for the hikari connection-pool
 spring.datasource.hikari.connection-timeout=8000


### PR DESCRIPTION
## Types of changes

Springdoc 2.8.x introduces OpenAPI 3.1, which isn’t fully backward-compatible with 3.0.1 (all our services currently use 3.0.1). That means all our service APIs need to be updated. One suggestion is to configure Springdoc to keep generating 3.0.1 for now and create a story for writing a migration guide to 3.1.

Here’s more about the issues people are seeing with 3.1:
- https://github.com/springdoc/springdoc-openapi/issues/2838
- https://github.com/springdoc/springdoc-openapi/issues/2841
- https://github.com/springdoc/springdoc-openapi/issues/2845
- https://github.com/springdoc/springdoc-openapi/issues/2840

And here’s OpenAPI’s official migration guide:
- https://www.openapis.org/blog/2021/02/16/migrating-from-openapi-3-0-to-3-1-0
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).