### PR TITLE
HYDRAN-2199: log silent 5xx/auth paths in ProblemExceptionHandler

### DIFF
--- a/dept44-starter/src/main/java/se/sundsvall/dept44/problem/ProblemExceptionHandler.java
+++ b/dept44-starter/src/main/java/se/sundsvall/dept44/problem/ProblemExceptionHandler.java
@@ -164,7 +164,7 @@ public class ProblemExceptionHandler extends ResponseEntityExceptionHandler {
 	@ResponseBody
 	public ResponseEntity<Problem> handleCallNotPermittedException(final CallNotPermittedException exception, final HttpServletRequest request) {
 		logWithContext(request, SERVICE_UNAVAILABLE.getReasonPhrase(), exception.getCausingCircuitBreakerName(),
-			() -> LOGGER.error("Circuit breaker '{}' is open, responding with {}", exception.getCausingCircuitBreakerName(), SERVICE_UNAVAILABLE.value()));
+			() -> LOGGER.warn("Circuit breaker '{}' is open, responding with {}", exception.getCausingCircuitBreakerName(), SERVICE_UNAVAILABLE.value()));
 
 		final var problem = Problem.valueOf(SERVICE_UNAVAILABLE, exception.getMessage());
 

--- a/dept44-starter/src/main/java/se/sundsvall/dept44/problem/ProblemExceptionHandler.java
+++ b/dept44-starter/src/main/java/se/sundsvall/dept44/problem/ProblemExceptionHandler.java
@@ -1,13 +1,18 @@
 package se.sundsvall.dept44.problem;
 
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import java.net.SocketTimeoutException;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
@@ -43,7 +48,14 @@ import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON;
 @ControllerAdvice
 public class ProblemExceptionHandler extends ResponseEntityExceptionHandler {
 
+	private static final Logger LOGGER = LoggerFactory.getLogger(ProblemExceptionHandler.class);
+
 	private static final String CONSTRAINT_VIOLATION_TITLE = "Constraint Violation";
+
+	private static final String MDC_REQUEST_PATH = "requestPath";
+	private static final String MDC_HTTP_METHOD = "httpMethod";
+	private static final String MDC_PROBLEM_TITLE = "problemTitle";
+	private static final String MDC_INTEGRATION_NAME = "integrationName";
 
 	/**
 	 * Override the central exception handling method to convert ProblemDetail responses to our ProblemResponse format. This
@@ -150,7 +162,10 @@ public class ProblemExceptionHandler extends ResponseEntityExceptionHandler {
 	 */
 	@ExceptionHandler(CallNotPermittedException.class)
 	@ResponseBody
-	public ResponseEntity<Problem> handleCallNotPermittedException(final CallNotPermittedException exception) {
+	public ResponseEntity<Problem> handleCallNotPermittedException(final CallNotPermittedException exception, final HttpServletRequest request) {
+		logWithContext(request, SERVICE_UNAVAILABLE.getReasonPhrase(), exception.getCausingCircuitBreakerName(),
+			() -> LOGGER.error("Circuit breaker '{}' is open, responding with {}", exception.getCausingCircuitBreakerName(), SERVICE_UNAVAILABLE.value()));
+
 		final var problem = Problem.valueOf(SERVICE_UNAVAILABLE, exception.getMessage());
 
 		return ResponseEntity
@@ -164,7 +179,10 @@ public class ProblemExceptionHandler extends ResponseEntityExceptionHandler {
 	 */
 	@ExceptionHandler(AccessDeniedException.class)
 	@ResponseBody
-	public ResponseEntity<Problem> handleAccessDeniedException(final AccessDeniedException exception) {
+	public ResponseEntity<Problem> handleAccessDeniedException(final AccessDeniedException exception, final HttpServletRequest request) {
+		logWithContext(request, FORBIDDEN.getReasonPhrase(), null,
+			() -> LOGGER.warn("Access denied ({}), responding with {}", exception.getClass().getSimpleName(), FORBIDDEN.value()));
+
 		return createProblem(FORBIDDEN, exception.getMessage());
 	}
 
@@ -173,7 +191,10 @@ public class ProblemExceptionHandler extends ResponseEntityExceptionHandler {
 	 */
 	@ExceptionHandler(AuthenticationException.class)
 	@ResponseBody
-	public ResponseEntity<Problem> handleAuthenticationException(final AuthenticationException exception) {
+	public ResponseEntity<Problem> handleAuthenticationException(final AuthenticationException exception, final HttpServletRequest request) {
+		logWithContext(request, UNAUTHORIZED.getReasonPhrase(), null,
+			() -> LOGGER.warn("Authentication failed ({}), responding with {}", exception.getClass().getSimpleName(), UNAUTHORIZED.value()));
+
 		return createProblem(UNAUTHORIZED, exception.getMessage());
 	}
 
@@ -200,7 +221,10 @@ public class ProblemExceptionHandler extends ResponseEntityExceptionHandler {
 	 */
 	@ExceptionHandler(SocketTimeoutException.class)
 	@ResponseBody
-	public ResponseEntity<Problem> handleSocketTimeoutException(final SocketTimeoutException exception) {
+	public ResponseEntity<Problem> handleSocketTimeoutException(final SocketTimeoutException exception, final HttpServletRequest request) {
+		logWithContext(request, GATEWAY_TIMEOUT.getReasonPhrase(), null,
+			() -> LOGGER.error("Downstream call timed out, responding with {}: {}", GATEWAY_TIMEOUT.value(), exception.getMessage()));
+
 		return createProblem(GATEWAY_TIMEOUT, exception.getMessage());
 	}
 
@@ -210,7 +234,10 @@ public class ProblemExceptionHandler extends ResponseEntityExceptionHandler {
 	 */
 	@ExceptionHandler(Exception.class)
 	@ResponseBody
-	public ResponseEntity<Problem> handleException(final Exception exception) {
+	public ResponseEntity<Problem> handleException(final Exception exception, final HttpServletRequest request) {
+		logWithContext(request, INTERNAL_SERVER_ERROR.getReasonPhrase(), null,
+			() -> LOGGER.error("Unhandled exception caught by global handler, responding with {}", INTERNAL_SERVER_ERROR.value(), exception));
+
 		return createProblem(INTERNAL_SERVER_ERROR, exception.getMessage());
 	}
 
@@ -235,6 +262,31 @@ public class ProblemExceptionHandler extends ResponseEntityExceptionHandler {
 			.withTitle(CONSTRAINT_VIOLATION_TITLE)
 			.withViolations(violations)
 			.build();
+	}
+
+	/**
+	 * Put the given context on the MDC, run the log statement so the values surface as structured (and OpenSearch
+	 * filterable) fields, then remove the keys again. Cleanup is mandatory since servlet threads are pooled and would
+	 * otherwise leak these fields onto subsequent requests.
+	 *
+	 * @param request         the current request, used for path and HTTP method
+	 * @param problemTitle    the title of the Problem being returned
+	 * @param integrationName the target integration name, or {@code null} when not available
+	 * @param logStatement    the logging call to execute while the context is on the MDC
+	 */
+	private static void logWithContext(final HttpServletRequest request, final String problemTitle, final String integrationName, final Runnable logStatement) {
+		try {
+			MDC.put(MDC_REQUEST_PATH, request.getRequestURI());
+			MDC.put(MDC_HTTP_METHOD, request.getMethod());
+			MDC.put(MDC_PROBLEM_TITLE, problemTitle);
+			Optional.ofNullable(integrationName).ifPresent(name -> MDC.put(MDC_INTEGRATION_NAME, name));
+			logStatement.run();
+		} finally {
+			MDC.remove(MDC_REQUEST_PATH);
+			MDC.remove(MDC_HTTP_METHOD);
+			MDC.remove(MDC_PROBLEM_TITLE);
+			MDC.remove(MDC_INTEGRATION_NAME);
+		}
 	}
 
 	private ResponseEntity<Problem> createProblem(final HttpStatus httpStatus, final String detail) {

--- a/dept44-starter/src/test/java/se/sundsvall/dept44/problem/ProblemExceptionHandlerTest.java
+++ b/dept44-starter/src/test/java/se/sundsvall/dept44/problem/ProblemExceptionHandlerTest.java
@@ -1,13 +1,22 @@
 package se.sundsvall.dept44.problem;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Path;
 import java.net.SocketTimeoutException;
 import java.util.List;
 import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.springframework.beans.TypeMismatchException;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpHeaders;
@@ -67,6 +76,33 @@ class ProblemExceptionHandlerTest {
 
 	private final ProblemExceptionHandler handler = new ProblemExceptionHandler();
 	private final ServletWebRequest webRequest = mock(ServletWebRequest.class);
+	private final HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+
+	private Logger handlerLogger;
+	private ListAppender<ILoggingEvent> appender;
+	private Level originalLevel;
+
+	@BeforeEach
+	void setUp() {
+		// Capture the handler's log events. The MDC is snapshotted eagerly (see MdcCapturingListAppender) because the
+		// handler clears its MDC entries in a finally block before the assertions run.
+		handlerLogger = (Logger) LoggerFactory.getLogger(ProblemExceptionHandler.class);
+		originalLevel = handlerLogger.getLevel();
+		handlerLogger.setLevel(Level.TRACE);
+		appender = new MdcCapturingListAppender();
+		appender.start();
+		handlerLogger.addAppender(appender);
+
+		when(httpServletRequest.getRequestURI()).thenReturn("/2281/resource");
+		when(httpServletRequest.getMethod()).thenReturn("GET");
+	}
+
+	@AfterEach
+	void tearDown() {
+		handlerLogger.detachAppender(appender);
+		appender.stop();
+		handlerLogger.setLevel(originalLevel);
+	}
 
 	@Test
 	void handleConstraintViolationException() {
@@ -191,7 +227,7 @@ class ProblemExceptionHandlerTest {
 		when(exception.getMessage()).thenReturn("CircuitBreaker 'petstore' is OPEN");
 
 		// Act
-		final var response = handler.handleCallNotPermittedException(exception);
+		final var response = handler.handleCallNotPermittedException(exception, httpServletRequest);
 
 		// Assert
 		assertThat(response.getStatusCode()).isEqualTo(SERVICE_UNAVAILABLE);
@@ -571,7 +607,7 @@ class ProblemExceptionHandlerTest {
 	void handleAccessDeniedException() {
 		final var exception = new AccessDeniedException("Access is denied");
 
-		final var response = handler.handleAccessDeniedException(exception);
+		final var response = handler.handleAccessDeniedException(exception, httpServletRequest);
 
 		assertThat(response.getStatusCode()).isEqualTo(FORBIDDEN);
 		assertThat(response.getHeaders().getContentType()).isEqualTo(APPLICATION_PROBLEM_JSON);
@@ -587,7 +623,7 @@ class ProblemExceptionHandlerTest {
 	void handleAuthenticationException() {
 		final var exception = new BadCredentialsException("Bad credentials");
 
-		final var response = handler.handleAuthenticationException(exception);
+		final var response = handler.handleAuthenticationException(exception, httpServletRequest);
 
 		assertThat(response.getStatusCode()).isEqualTo(UNAUTHORIZED);
 		assertThat(response.getHeaders().getContentType()).isEqualTo(APPLICATION_PROBLEM_JSON);
@@ -635,7 +671,7 @@ class ProblemExceptionHandlerTest {
 	void handleSocketTimeoutException() {
 		final var exception = new SocketTimeoutException("Read timed out");
 
-		final var response = handler.handleSocketTimeoutException(exception);
+		final var response = handler.handleSocketTimeoutException(exception, httpServletRequest);
 
 		assertThat(response.getStatusCode()).isEqualTo(GATEWAY_TIMEOUT);
 		assertThat(response.getHeaders().getContentType()).isEqualTo(APPLICATION_PROBLEM_JSON);
@@ -651,7 +687,7 @@ class ProblemExceptionHandlerTest {
 	void handleGenericException() {
 		final var exception = new RuntimeException("Something unexpected happened");
 
-		final var response = handler.handleException(exception);
+		final var response = handler.handleException(exception, httpServletRequest);
 
 		assertThat(response.getStatusCode()).isEqualTo(INTERNAL_SERVER_ERROR);
 		assertThat(response.getHeaders().getContentType()).isEqualTo(APPLICATION_PROBLEM_JSON);
@@ -667,7 +703,7 @@ class ProblemExceptionHandlerTest {
 	void handleGenericExceptionWithNullMessage() {
 		final var exception = new NullPointerException();
 
-		final var response = handler.handleException(exception);
+		final var response = handler.handleException(exception, httpServletRequest);
 
 		assertThat(response.getStatusCode()).isEqualTo(INTERNAL_SERVER_ERROR);
 		assertThat(response.getHeaders().getContentType()).isEqualTo(APPLICATION_PROBLEM_JSON);
@@ -709,6 +745,126 @@ class ProblemExceptionHandlerTest {
 
 		assertThat(response).isNotNull();
 		assertThat(response.getBody()).isEqualTo(customBody);
+	}
+
+	// -----------------------------------------------------------------------------------------------------------------
+	// Structured logging (MDC + level) for the previously-silent 5xx/auth handlers (HYDRAN-2197)
+	// -----------------------------------------------------------------------------------------------------------------
+
+	@Test
+	void handleExceptionLogsErrorWithStacktraceAndContext() {
+		handler.handleException(new RuntimeException("boom"), httpServletRequest);
+
+		final var event = eventOf("Unhandled exception");
+		assertThat(event.getLevel()).isEqualTo(Level.ERROR);
+		assertThat(event.getThrowableProxy()).isNotNull();
+		assertThat(event.getMDCPropertyMap())
+			.containsEntry("requestPath", "/2281/resource")
+			.containsEntry("httpMethod", "GET")
+			.containsEntry("problemTitle", "Internal Server Error");
+
+		assertMdcCleared();
+	}
+
+	@Test
+	void handleCallNotPermittedExceptionLogsErrorWithIntegrationName() {
+		final var exception = mock(CallNotPermittedException.class);
+		when(exception.getCausingCircuitBreakerName()).thenReturn("petstore");
+
+		handler.handleCallNotPermittedException(exception, httpServletRequest);
+
+		final var event = eventOf("Circuit breaker");
+		assertThat(event.getLevel()).isEqualTo(Level.ERROR);
+		assertThat(event.getThrowableProxy()).isNull();
+		assertThat(event.getMDCPropertyMap())
+			.containsEntry("requestPath", "/2281/resource")
+			.containsEntry("httpMethod", "GET")
+			.containsEntry("problemTitle", "Service Unavailable")
+			.containsEntry("integrationName", "petstore");
+
+		assertMdcCleared();
+	}
+
+	@Test
+	void handleSocketTimeoutExceptionLogsErrorWithoutIntegrationName() {
+		handler.handleSocketTimeoutException(new SocketTimeoutException("Read timed out"), httpServletRequest);
+
+		final var event = eventOf("Downstream call timed out");
+		assertThat(event.getLevel()).isEqualTo(Level.ERROR);
+		assertThat(event.getThrowableProxy()).isNull();
+		assertThat(event.getMDCPropertyMap())
+			.containsEntry("requestPath", "/2281/resource")
+			.containsEntry("httpMethod", "GET")
+			.containsEntry("problemTitle", "Gateway Timeout")
+			.doesNotContainKey("integrationName");
+
+		assertMdcCleared();
+	}
+
+	@Test
+	void handleAuthenticationExceptionLogsWarnWithoutPii() {
+		// The exception message carries a (fictional) PII token that must never reach the log line.
+		handler.handleAuthenticationException(new BadCredentialsException("secret-user@example.com"), httpServletRequest);
+
+		final var event = eventOf("Authentication failed");
+		assertThat(event.getLevel()).isEqualTo(Level.WARN);
+		assertThat(event.getThrowableProxy()).isNull();
+		assertThat(event.getFormattedMessage())
+			.doesNotContain("secret-user@example.com")
+			.contains("BadCredentialsException")
+			.contains("401");
+		assertThat(event.getMDCPropertyMap())
+			.containsEntry("requestPath", "/2281/resource")
+			.containsEntry("httpMethod", "GET")
+			.containsEntry("problemTitle", "Unauthorized");
+
+		assertMdcCleared();
+	}
+
+	@Test
+	void handleAccessDeniedExceptionLogsWarnWithoutPii() {
+		handler.handleAccessDeniedException(new AccessDeniedException("secret-user@example.com"), httpServletRequest);
+
+		final var event = eventOf("Access denied");
+		assertThat(event.getLevel()).isEqualTo(Level.WARN);
+		assertThat(event.getThrowableProxy()).isNull();
+		assertThat(event.getFormattedMessage())
+			.doesNotContain("secret-user@example.com")
+			.contains("AccessDeniedException")
+			.contains("403");
+		assertThat(event.getMDCPropertyMap())
+			.containsEntry("requestPath", "/2281/resource")
+			.containsEntry("httpMethod", "GET")
+			.containsEntry("problemTitle", "Forbidden");
+
+		assertMdcCleared();
+	}
+
+	private ILoggingEvent eventOf(final String messageFragment) {
+		return appender.list.stream()
+			.filter(event -> event.getFormattedMessage().contains(messageFragment))
+			.findFirst()
+			.orElseThrow();
+	}
+
+	private void assertMdcCleared() {
+		assertThat(MDC.get("requestPath")).isNull();
+		assertThat(MDC.get("httpMethod")).isNull();
+		assertThat(MDC.get("problemTitle")).isNull();
+		assertThat(MDC.get("integrationName")).isNull();
+	}
+
+	/**
+	 * {@link ListAppender} that eagerly snapshots the MDC of each event as it is appended. This is required because the
+	 * handler removes its MDC entries in a finally block, and {@link ILoggingEvent#getMDCPropertyMap()} is otherwise
+	 * resolved lazily (i.e. after the MDC has already been cleared).
+	 */
+	private static class MdcCapturingListAppender extends ListAppender<ILoggingEvent> {
+		@Override
+		protected void append(final ILoggingEvent eventObject) {
+			eventObject.getMDCPropertyMap();
+			super.append(eventObject);
+		}
 	}
 
 	// Helper method for MissingPathVariableException test

--- a/dept44-starter/src/test/java/se/sundsvall/dept44/problem/ProblemExceptionHandlerTest.java
+++ b/dept44-starter/src/test/java/se/sundsvall/dept44/problem/ProblemExceptionHandlerTest.java
@@ -767,14 +767,14 @@ class ProblemExceptionHandlerTest {
 	}
 
 	@Test
-	void handleCallNotPermittedExceptionLogsErrorWithIntegrationName() {
+	void handleCallNotPermittedExceptionLogsWarnWithIntegrationName() {
 		final var exception = mock(CallNotPermittedException.class);
 		when(exception.getCausingCircuitBreakerName()).thenReturn("petstore");
 
 		handler.handleCallNotPermittedException(exception, httpServletRequest);
 
 		final var event = eventOf("Circuit breaker");
-		assertThat(event.getLevel()).isEqualTo(Level.ERROR);
+		assertThat(event.getLevel()).isEqualTo(Level.WARN);
 		assertThat(event.getThrowableProxy()).isNull();
 		assertThat(event.getMDCPropertyMap())
 			.containsEntry("requestPath", "/2281/resource")


### PR DESCRIPTION
## Context

`ProblemExceptionHandler` (the global `@ControllerAdvice` that converts exceptions to RFC-9457 Problem JSON) emits **no log statements of its own**. That leaves specific paths where a 5xx/auth error produces a response but **nothing is logged anywhere**:

- **Catch-all 500** (`handleException`) — an unexpected exception (e.g. a forgotten `try/catch` in a service) is converted to a 500 and returned silently, with no stacktrace or context.
- **Circuit-breaker open** (`CallNotPermittedException` → 503) — silent.
- **Downstream timeout** (`SocketTimeoutException` → 504) — silent.
- **Auth/access** (`AuthenticationException` → 401, `AccessDeniedException` → 403) — silent.

I verified these are genuinely silent today: Feign's own logger is DEBUG under a category pinned to INFO; Logbook needs a response (a timeout has none); the error decoder only logs on a narrow extraction-failure path and isn't invoked for timeouts; and no resilience4j event listener logs breaker open/rejection. So this adds the first and only log line on each path — **no double-logging**.

## Change

Add structured logging to exactly those paths:

| Handler | Status | Level | Notes |
|---|---|---|---|
| `handleException` (catch-all) | 500 | **ERROR** + full stacktrace | |
| `handleCallNotPermittedException` | 503 | **WARN** | `integrationName` = `getCausingCircuitBreakerName()`; WARN so an open breaker doesn't flood the ERROR channel |
| `handleSocketTimeoutException` | 504 | **ERROR** | no integration name available on a raw timeout |
| `handleAuthenticationException` | 401 | **WARN** | **no PII** — exception class name only |
| `handleAccessDeniedException` | 403 | **WARN** | **no PII** |

- Context (`requestPath`, `httpMethod`, `problemTitle`, `integrationName`) is emitted as **MDC fields**, so it surfaces as discrete, filterable `_`-prefixed fields in OpenSearch via the GELF encoder (`includeMdcData=true`). `x-request-id` / `municipalityId` already ride along from the servlet filters.
- A private `logWithContext(...)` helper puts the context, runs the log, and **removes the keys in a `finally`** (pooled servlet threads must not leak fields).
- Request path/method come from an injected `HttpServletRequest` parameter (resolved by Spring; does not affect handler selection).
- **Response bodies are unchanged.** The 4xx-validation and 404 paths, and deliberately-thrown `ThrowableProblem`s, are untouched (handled by the parent via `handleExceptionInternal`).

### Note on Feign timeouts
A Feign read/connect timeout propagates as `feign.RetryableException` (cause = `SocketTimeoutException`), which Spring routes to the **catch-all (500, with stacktrace)** rather than `handleSocketTimeoutException` (504). That routing is pre-existing; the net effect here is that Feign timeouts are now logged (once) via the catch-all. Surfacing them as 504 instead would need a separate `@ExceptionHandler(RetryableException.class)` — out of scope for this ticket.

## Tests
- Added `MdcCapturingListAppender` (eager MDC snapshot) + one logging test per handler asserting level, MDC fields, MDC cleanup, stacktrace presence (500), circuit-breaker name (503), absent integration name (504), and the no-PII guarantee (401/403).
- Updated existing call-sites to pass a mocked `HttpServletRequest`.

## Verification
- `ProblemExceptionHandlerTest`: 42/42 pass; full `dept44-starter` module: 407/407 pass.
- `mvn dept44-formatting:check`: clean.
- JaCoCo: "All coverage checks have been met" (85% line + branch).
- `mvn -pl dept44-starter verify`: BUILD SUCCESS.