### PR TITLE
HYDRAN-2200: Add PII masking (PiiMasker + opt-in logback PiiMaskingConverter)

### DIFF
--- a/dept44-starter-logback-logserver/readme.md
+++ b/dept44-starter-logback-logserver/readme.md
@@ -51,10 +51,44 @@ If needed, provide your own `logback-spring.xml` in your service to override thi
 
 ### Properties
 
-|                Property                 | Default |              Description              |
-|-----------------------------------------|---------|---------------------------------------|
-| `dept44.logback.logserver.disabled`     | `false` | Set to `true` to disable GELF logging |
-| `dept44.logback.logserver.maxchunksize` | `508`   | Max GELF chunk size in bytes          |
+|                Property                 | Default |                       Description                       |
+|-----------------------------------------|---------|---------------------------------------------------------|
+| `dept44.logback.logserver.disabled`     | `false` | Set to `true` to disable GELF logging                   |
+| `dept44.logback.logserver.maxchunksize` | `508`   | Max GELF chunk size in bytes                            |
+| `dept44.logback.pii-masking.enabled`    | `false` | Set to `true` to mask PII in all log output (see below) |
+
+### PII masking
+
+Set `dept44.logback.pii-masking.enabled=true` to mask personally identifiable information in **every** log line -
+console and GELF - regardless of whether the producing code remembered to mask the value itself. The following are
+masked:
+
+|           Category            |             Example input              |   Masked output    |
+|-------------------------------|----------------------------------------|--------------------|
+| Swedish personal identity no. | `900101-1234`                          | `******-****`      |
+| UUID (`partyId`)              | `f47ac10b-58cc-4372-a567-0e02b2c3d479` | `f47a...`          |
+| E-mail address                | `john.doe@example.com`                 | `j***@example.com` |
+| Swedish phone number          | `070-123 45 67`                        | `***-*** ** **`    |
+
+The masking is performed by the `%maskPii` pattern conversion word (class
+`se.sundsvall.dept44.util.PiiMasker` / `se.sundsvall.dept44.logback.PiiMaskingConverter`). When disabled it renders
+identically to `%m`, so there is no behavioural change in the default configuration.
+
+> **Note:** this is distinct from `LogUtils.sanitizeForLogging`, which guards against *log injection*, not PII.
+
+**Limitations:**
+
+- Only the rendered **message** is masked. MDC values, caller data and exception/stack-trace content emitted by the GELF
+  encoder as separate fields are **not** masked.
+- **Street addresses are not masked.** Free-form addresses have no stable shape a regex can match without masking large
+  amounts of ordinary log text; mask them field-by-field at the source instead (or via Logbook JSONPath/XPath body
+  masking for HTTP payloads).
+- The personal-identity-number rule keys on the digit shape `\b\d{6}[-+]?\d{4}\b` and cannot distinguish a real
+  personnummer from any other free-standing ten-digit number, so some non-PII numbers may be masked.
+- Phone-number masking only catches structured Swedish numbers (a `+46`/`0046` prefix or an internal separator); a bare
+  digit run like `0701234567` is treated as a personal identity number.
+- A service that provides its own `logback-spring.xml` (see [Override Configuration](#override-configuration)) must
+  replicate the `<conversionRule>` and `%maskPii` patterns to keep masking.
 
 ### Chunk Size
 

--- a/dept44-starter-logback-logserver/src/main/resources/application.properties
+++ b/dept44-starter-logback-logserver/src/main/resources/application.properties
@@ -2,3 +2,6 @@
 dept44.logback.logserver.disabled=false
 # Max size of a GELF chunk in bytes. Maximum supported is 65467 bytes.
 dept44.logback.logserver.maxchunksize=508
+# Mask PII (Swedish personal identity numbers, UUIDs/partyId, e-mail addresses, Swedish phone numbers) in all log output. Opt-in; default false.
+# Masks the rendered message only - MDC values, caller data and stack traces are not masked. See PiiMasker / PiiMaskingConverter.
+dept44.logback.pii-masking.enabled=false

--- a/dept44-starter-logback-logserver/src/main/resources/logback-spring.xml
+++ b/dept44-starter-logback-logserver/src/main/resources/logback-spring.xml
@@ -12,10 +12,17 @@
     <property scope="context" name="instanceId" value="${INSTANCE_ID:-unknown}"/>
     <property scope="context" name="serviceVersion" value="${SERVICE_VERSION:-unknown}"/>
 
-    <property name="CONSOLE_LOG_PATTERN" value="%date{ISO8601} [%t] ${instanceId} ${serviceVersion} %12X{x-request-id} %5p %-40.40logger{39} %m%n%xEx" />
+    <property name="CONSOLE_LOG_PATTERN" value="%date{ISO8601} [%t] ${instanceId} ${serviceVersion} %12X{x-request-id} %5p %-40.40logger{39} %maskPii%n%xEx" />
 
     <springProperty scope="context" name="applicationName" source="spring.application.name" defaultValue="name-not-set"/>
     <springProperty scope="context" name="maxChunkSize" source="dept44.logback.logserver.maxchunksize" defaultValue="508"/>
+
+    <!-- PII masking. Bridge the Spring property into the logback context so PiiMaskingConverter can read it in start(),
+         and register the %maskPii conversion word used in the console and GELF patterns below. Masking is opt-in and
+         defaults to off; when off, %maskPii renders identically to %m. Note: %maskPii only masks the rendered message -
+         MDC values, caller data and stack traces emitted as separate GELF fields are not masked. -->
+    <springProperty scope="context" name="DEPT44_PII_MASKING_ENABLED" source="dept44.logback.pii-masking.enabled" defaultValue="false"/>
+    <conversionRule conversionWord="maskPii" class="se.sundsvall.dept44.logback.PiiMaskingConverter"/>
 
     <condition class="ch.qos.logback.core.boolex.ExpressionPropertyCondition">
         <expression>isDefined("LOGSERVER_HOST") &amp;&amp; !propertyContains("dept44.logback.logserver.disabled", "true")</expression>
@@ -35,10 +42,10 @@
                     <includeLevelName>true</includeLevelName>
                     <shortPatternLayout class="ch.qos.logback.classic.PatternLayout">
                         <!-- Only display the first 100 chars in the short message -->
-                        <pattern>%.-100m%nopex</pattern>
+                        <pattern>%.-100maskPii%nopex</pattern>
                     </shortPatternLayout>
                     <fullPatternLayout class="ch.qos.logback.classic.PatternLayout">
-                        <pattern>%m%n</pattern>
+                        <pattern>%maskPii%n</pattern>
                     </fullPatternLayout>
                     <staticField>application_name:${applicationName}</staticField>
                     <staticField>spring_profile:${SPRING_PROFILES_ACTIVE}</staticField> <!-- Defined as environment variable -->

--- a/dept44-starter/src/main/java/se/sundsvall/dept44/logback/PiiMaskingConverter.java
+++ b/dept44-starter/src/main/java/se/sundsvall/dept44/logback/PiiMaskingConverter.java
@@ -1,0 +1,51 @@
+package se.sundsvall.dept44.logback;
+
+import ch.qos.logback.classic.pattern.ClassicConverter;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import se.sundsvall.dept44.util.PiiMasker;
+
+/**
+ * Logback pattern converter that masks PII in the rendered message of every log event, so that personal data is hidden
+ * even when a developer forgets to call {@link PiiMasker} manually.
+ *
+ * <p>
+ * It is registered as a conversion word (e.g. {@code maskPii}) via a {@code <conversionRule>} and used in place of
+ * {@code %m} in pattern layouts. Masking is opt-in: it is only active when the logback context property
+ * {@value #ENABLED_PROPERTY} is {@code true} (wired from the Spring property
+ * {@code dept44.logback.pii-masking.enabled}). When disabled, {@link #convert(ILoggingEvent)} returns the message
+ * unchanged, so the output is identical to {@code %m}. The flag is read once in {@link #start()} and cached - there is
+ * no per-line property lookup.
+ *
+ * <p>
+ * <strong>Why a converter and not a {@code Filter}:</strong> this component fulfils the requirement of a
+ * "PII masking filter", but it is deliberately implemented as a {@link ClassicConverter} rather than a logback
+ * {@code Filter}/{@code TurboFilter}. A logback filter can only accept or deny an event; it cannot rewrite the message
+ * text ({@link ILoggingEvent} exposes no message setter). A pattern converter is the only extension point that can
+ * transform the rendered content of every log line.
+ *
+ * <p>
+ * <strong>Scope:</strong> this masks the rendered <em>message</em> only. Fields the GELF encoder emits separately - MDC
+ * values, caller data and exception/stack-trace content - do not pass through this converter and are therefore not
+ * masked by it.
+ *
+ * @see PiiMasker#maskPii(String)
+ */
+public class PiiMaskingConverter extends ClassicConverter {
+
+	/** Logback context property that toggles masking. Sourced from {@code dept44.logback.pii-masking.enabled}. */
+	static final String ENABLED_PROPERTY = "DEPT44_PII_MASKING_ENABLED";
+
+	private boolean enabled;
+
+	@Override
+	public void start() {
+		this.enabled = Boolean.parseBoolean(getContext().getProperty(ENABLED_PROPERTY));
+		super.start();
+	}
+
+	@Override
+	public String convert(final ILoggingEvent event) {
+		final var message = event.getFormattedMessage();
+		return enabled ? PiiMasker.maskPii(message) : message;
+	}
+}

--- a/dept44-starter/src/main/java/se/sundsvall/dept44/util/LogUtils.java
+++ b/dept44-starter/src/main/java/se/sundsvall/dept44/util/LogUtils.java
@@ -20,9 +20,15 @@ public final class LogUtils {
 	 * 
 	 * If the input is {@code null}, the method returns {@code null}.
 	 *
+	 * <p>
+	 * <strong>Note:</strong> this method does <em>not</em> mask personal data (PII) - it only guards against log
+	 * injection. To mask Swedish personal identity numbers, UUIDs/{@code partyId} and e-mail addresses, use
+	 * {@link se.sundsvall.dept44.util.PiiMasker#maskPii(String)}.
+	 *
 	 * @param  input the string to sanitize
 	 * @return       a sanitized version of the input string suitable for logging, or {@code null} if the input was
 	 *               {@code null}
+	 * @see          se.sundsvall.dept44.util.PiiMasker#maskPii(String)
 	 */
 	public static String sanitizeForLogging(String input) {
 		return Optional.ofNullable(input)

--- a/dept44-starter/src/main/java/se/sundsvall/dept44/util/PiiMasker.java
+++ b/dept44-starter/src/main/java/se/sundsvall/dept44/util/PiiMasker.java
@@ -1,0 +1,152 @@
+package se.sundsvall.dept44.util;
+
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+/**
+ * Masks personally identifiable information (PII) in strings so it can be logged without exposing personal data.
+ *
+ * <p>
+ * This class handles the PII categories most commonly leaked into logs in Sundsvall services:
+ * <ul>
+ * <li>Swedish personal identity numbers ({@code personnummer}) &rarr; {@code ******-****}</li>
+ * <li>UUIDs (typically a {@code partyId}) &rarr; the first four characters followed by {@code ...}</li>
+ * <li>E-mail addresses &rarr; the first character of the local part followed by {@code ***@} and the domain</li>
+ * <li>Structured Swedish phone numbers &rarr; every digit replaced with {@code *}, separators kept</li>
+ * </ul>
+ *
+ * <p>
+ * <strong>This is not the same thing as {@link LogUtils#sanitizeForLogging(String)}.</strong>
+ * {@code sanitizeForLogging}
+ * protects against <em>log injection</em> (CRLF and control characters that let an attacker forge log lines); it does
+ * <em>not</em> hide personal data. The methods in this class do the opposite: they mask personal data but do
+ * <em>not</em> protect against log injection. The two are complementary - apply both when a value is both attacker
+ * controlled and contains PII.
+ *
+ * <p>
+ * <strong>Limitation:</strong> the personal-identity-number matcher keys on the digit shape {@code NNNNNN[-+]?NNNN} and
+ * cannot tell a real personnummer apart from any other free-standing ten-digit number (an order number, an epoch-
+ * millisecond timestamp, a correlation id). Such numbers may be masked even though they are not PII. Eliminating this
+ * would require a date/checksum validation that is intentionally out of scope here.
+ *
+ * <p>
+ * <strong>Not handled:</strong> free-form street addresses are deliberately not masked - they have no stable shape a
+ * regex can match without masking large amounts of ordinary log text. Mask addresses field-by-field at the source
+ * instead (or via the Logbook JSONPath/XPath body masking for HTTP payloads). The phone-number matcher only catches
+ * structured Swedish numbers (a {@code +46}/{@code 0046} prefix or an internal separator); a bare run of digits such as
+ * {@code 0701234567} is treated as a personal identity number, not a phone number.
+ *
+ * @see LogUtils#sanitizeForLogging(String)
+ */
+public final class PiiMasker {
+
+	/**
+	 * Swedish personal identity number on the {@code NNNNNN[-+]?NNNN} form. The {@code \b} word boundaries keep a
+	 * ten-digit run that is part of a longer number (or token) from matching.
+	 */
+	private static final Pattern PERSONAL_NUMBER_PATTERN = Pattern.compile("\\b\\d{6}[-+]?\\d{4}\\b");
+
+	private static final String PERSONAL_NUMBER_MASK = "******-****";
+
+	/**
+	 * Structured Swedish phone number: either a {@code +46}/{@code 0046} country-code prefix, or a national number with a
+	 * leading {@code 0} and at least one space/hyphen separator. Requiring that structure keeps a bare run of digits from
+	 * matching (such a run is handled by {@link #maskPersonalNumber(String)} instead).
+	 */
+	private static final Pattern PHONE_NUMBER_PATTERN = Pattern.compile(
+		"(?<!\\w)(?:(?:\\+46|0046)[\\s-]?\\d(?:[\\s-]?\\d){6,10}|0\\d{1,3}[\\s-]\\d{2,4}(?:[\\s-]?\\d{2,3}){1,2})(?!\\d)");
+
+	/** UUID in the canonical {@code 8-4-4-4-12} hexadecimal form, e.g. a {@code partyId}. */
+	private static final Pattern UUID_PATTERN = Pattern.compile("\\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\\b");
+
+	/** E-mail address. Group 1 captures the local part, group 2 captures the domain. */
+	private static final Pattern EMAIL_PATTERN = Pattern.compile("([A-Za-z0-9._%+-]+)@([A-Za-z0-9.-]+\\.[A-Za-z]{2,})");
+
+	private PiiMasker() {}
+
+	/**
+	 * Masks every supported PII category in the given string in one pass.
+	 *
+	 * <p>
+	 * The categories are applied in a deliberate order - UUID, then phone number, then personal identity number, then
+	 * e-mail - so that one mask cannot corrupt another's match (e.g. the personal-number matcher biting into the twelve
+	 * hexadecimal digits of a UUID or the digits of a structured phone number, or a masked value being mistaken for an
+	 * e-mail).
+	 *
+	 * <p>
+	 * This masks personal data only; it does <em>not</em> protect against log injection. For that, use
+	 * {@link LogUtils#sanitizeForLogging(String)}.
+	 *
+	 * @param  input the string to mask
+	 * @return       a copy with all supported PII masked, or {@code null} if the input was {@code null}
+	 * @see          LogUtils#sanitizeForLogging(String)
+	 */
+	public static String maskPii(final String input) {
+		return Optional.ofNullable(input)
+			.map(PiiMasker::maskUuid)
+			.map(PiiMasker::maskPhoneNumber)
+			.map(PiiMasker::maskPersonalNumber)
+			.map(PiiMasker::maskEmail)
+			.orElse(null);
+	}
+
+	/**
+	 * Masks Swedish personal identity numbers on the {@code NNNNNN[-+]?NNNN} form, replacing each with
+	 * {@code ******-****}.
+	 *
+	 * <p>
+	 * Note the limitation described on the {@linkplain PiiMasker class}: any free-standing ten-digit number matches this
+	 * shape and will be masked, whether or not it is an actual personnummer.
+	 *
+	 * @param  input the string to mask
+	 * @return       a copy with personal identity numbers masked, or {@code null} if the input was {@code null}
+	 */
+	public static String maskPersonalNumber(final String input) {
+		return Optional.ofNullable(input)
+			.map(value -> PERSONAL_NUMBER_PATTERN.matcher(value).replaceAll(PERSONAL_NUMBER_MASK))
+			.orElse(null);
+	}
+
+	/**
+	 * Masks structured Swedish phone numbers by replacing every digit with {@code *} while keeping separators, e.g.
+	 * {@code 070-123 45 67} becomes {@code ***-*** ** **} and {@code +46 70 123 45 67} becomes {@code +** ** *** ** **}.
+	 *
+	 * <p>
+	 * Only numbers with phone-like structure are matched - a {@code +46}/{@code 0046} prefix or an internal separator. A
+	 * bare run of digits is left to {@link #maskPersonalNumber(String)}.
+	 *
+	 * @param  input the string to mask
+	 * @return       a copy with structured phone numbers masked, or {@code null} if the input was {@code null}
+	 */
+	public static String maskPhoneNumber(final String input) {
+		return Optional.ofNullable(input)
+			.map(value -> PHONE_NUMBER_PATTERN.matcher(value).replaceAll(match -> match.group().replaceAll("\\d", "*")))
+			.orElse(null);
+	}
+
+	/**
+	 * Masks UUIDs (such as a {@code partyId}) by keeping only the first four characters and appending {@code ...}, e.g.
+	 * {@code f47ac10b-58cc-4372-a567-0e02b2c3d479} becomes {@code f47a...}.
+	 *
+	 * @param  input the string to mask
+	 * @return       a copy with UUIDs masked, or {@code null} if the input was {@code null}
+	 */
+	public static String maskUuid(final String input) {
+		return Optional.ofNullable(input)
+			.map(value -> UUID_PATTERN.matcher(value).replaceAll(match -> match.group().substring(0, 4) + "..."))
+			.orElse(null);
+	}
+
+	/**
+	 * Masks e-mail addresses by keeping the first character of the local part and the domain, replacing the rest of the
+	 * local part with {@code ***}, e.g. {@code john.doe@example.com} becomes {@code j***@example.com}.
+	 *
+	 * @param  input the string to mask
+	 * @return       a copy with e-mail addresses masked, or {@code null} if the input was {@code null}
+	 */
+	public static String maskEmail(final String input) {
+		return Optional.ofNullable(input)
+			.map(value -> EMAIL_PATTERN.matcher(value).replaceAll(match -> match.group(1).substring(0, 1) + "***@" + match.group(2)))
+			.orElse(null);
+	}
+}

--- a/dept44-starter/src/test/java/se/sundsvall/dept44/logback/PiiMaskingConverterTest.java
+++ b/dept44-starter/src/test/java/se/sundsvall/dept44/logback/PiiMaskingConverterTest.java
@@ -1,0 +1,60 @@
+package se.sundsvall.dept44.logback;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.PatternLayout;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PiiMaskingConverterTest {
+
+	private static final String MESSAGE = "User john.doe@example.com partyId f47ac10b-58cc-4372-a567-0e02b2c3d479 ssn 900101-1234";
+	private static final String MASKED = "User j***@example.com partyId f47a... ssn ******-****";
+
+	private final LoggerContext context = new LoggerContext();
+
+	@Test
+	void masksWhenEnabled() {
+		assertThat(startedConverter("true").convert(event(MESSAGE))).isEqualTo(MASKED);
+	}
+
+	@Test
+	void returnsMessageVerbatimWhenDisabled() {
+		assertThat(startedConverter("false").convert(event(MESSAGE))).isEqualTo(MESSAGE);
+	}
+
+	@Test
+	void returnsMessageVerbatimWhenPropertyAbsent() {
+		assertThat(startedConverter(null).convert(event(MESSAGE))).isEqualTo(MESSAGE);
+	}
+
+	@Test
+	void resolvesConversionWordThroughPatternLayout() {
+		context.putProperty(PiiMaskingConverter.ENABLED_PROPERTY, "true");
+
+		final var layout = new PatternLayout();
+		layout.setContext(context);
+		layout.getInstanceConverterMap().put("maskPii", PiiMaskingConverter::new);
+		layout.setPattern("%maskPii");
+		layout.start();
+
+		assertThat(layout.doLayout(event(MESSAGE))).isEqualTo(MASKED);
+	}
+
+	private PiiMaskingConverter startedConverter(final String enabledValue) {
+		if (enabledValue != null) {
+			context.putProperty(PiiMaskingConverter.ENABLED_PROPERTY, enabledValue);
+		}
+		final var converter = new PiiMaskingConverter();
+		converter.setContext(context);
+		converter.start();
+		return converter;
+	}
+
+	private ILoggingEvent event(final String message) {
+		return new LoggingEvent(getClass().getName(), context.getLogger("test"), Level.INFO, message, null, null);
+	}
+}

--- a/dept44-starter/src/test/java/se/sundsvall/dept44/util/PiiMaskerTest.java
+++ b/dept44-starter/src/test/java/se/sundsvall/dept44/util/PiiMaskerTest.java
@@ -1,0 +1,104 @@
+package se.sundsvall.dept44.util;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PiiMaskerTest {
+
+	@ParameterizedTest
+	@MethodSource("maskPersonalNumberArguments")
+	void maskPersonalNumber(final String input, final String expected) {
+		assertThat(PiiMasker.maskPersonalNumber(input)).isEqualTo(expected);
+	}
+
+	private static Stream<Arguments> maskPersonalNumberArguments() {
+		return Stream.of(
+			Arguments.of(null, null),
+			Arguments.of("", ""),
+			Arguments.of("900101-1234", "******-****"),
+			Arguments.of("9001011234", "******-****"),
+			Arguments.of("900101+1234", "******-****"),
+			Arguments.of("Patient 900101-1234 admitted", "Patient ******-**** admitted"),
+			// A 14-digit run is not a personnummer; the \b boundaries keep it from matching.
+			Arguments.of("Order 12345678901234 shipped", "Order 12345678901234 shipped"),
+			Arguments.of("no digits here", "no digits here"),
+			Arguments.of("900101-1234 and 850615-4321", "******-**** and ******-****"));
+	}
+
+	@ParameterizedTest
+	@MethodSource("maskPhoneNumberArguments")
+	void maskPhoneNumber(final String input, final String expected) {
+		assertThat(PiiMasker.maskPhoneNumber(input)).isEqualTo(expected);
+	}
+
+	private static Stream<Arguments> maskPhoneNumberArguments() {
+		return Stream.of(
+			Arguments.of(null, null),
+			Arguments.of("", ""),
+			Arguments.of("070-123 45 67", "***-*** ** **"),
+			Arguments.of("+46 70 123 45 67", "+** ** *** ** **"),
+			Arguments.of("0046 70 123 45 67", "**** ** *** ** **"),
+			Arguments.of("+46701234567", "+***********"),
+			Arguments.of("08-123 456 78", "**-*** *** **"),
+			Arguments.of("Call 060-12 34 56 today", "Call ***-** ** ** today"),
+			// A bare digit run has no phone structure; it is left to the personal-number rule, so it is unchanged here.
+			Arguments.of("0701234567", "0701234567"),
+			Arguments.of("no phone here", "no phone here"));
+	}
+
+	@ParameterizedTest
+	@MethodSource("maskUuidArguments")
+	void maskUuid(final String input, final String expected) {
+		assertThat(PiiMasker.maskUuid(input)).isEqualTo(expected);
+	}
+
+	private static Stream<Arguments> maskUuidArguments() {
+		return Stream.of(
+			Arguments.of(null, null),
+			Arguments.of("", ""),
+			Arguments.of("f47ac10b-58cc-4372-a567-0e02b2c3d479", "f47a..."),
+			Arguments.of("F47AC10B-58CC-4372-A567-0E02B2C3D479", "F47A..."),
+			Arguments.of("partyId f47ac10b-58cc-4372-a567-0e02b2c3d479 done", "partyId f47a... done"),
+			Arguments.of("not-a-uuid", "not-a-uuid"),
+			Arguments.of("f47ac10b-58cc-4372-a567-0e02b2c3d479 / 11111111-2222-3333-4444-555555555555", "f47a... / 1111..."));
+	}
+
+	@ParameterizedTest
+	@MethodSource("maskEmailArguments")
+	void maskEmail(final String input, final String expected) {
+		assertThat(PiiMasker.maskEmail(input)).isEqualTo(expected);
+	}
+
+	private static Stream<Arguments> maskEmailArguments() {
+		return Stream.of(
+			Arguments.of(null, null),
+			Arguments.of("", ""),
+			Arguments.of("john.doe@example.com", "j***@example.com"),
+			Arguments.of("a@b.co", "a***@b.co"),
+			Arguments.of("Contact john.doe@example.com today", "Contact j***@example.com today"),
+			Arguments.of("no email here", "no email here"),
+			Arguments.of("a@b.com, c@d.org", "a***@b.com, c***@d.org"));
+	}
+
+	@ParameterizedTest
+	@MethodSource("maskPiiArguments")
+	void maskPii(final String input, final String expected) {
+		assertThat(PiiMasker.maskPii(input)).isEqualTo(expected);
+	}
+
+	private static Stream<Arguments> maskPiiArguments() {
+		return Stream.of(
+			Arguments.of(null, null),
+			Arguments.of("", ""),
+			Arguments.of("nothing to mask", "nothing to mask"),
+			Arguments.of(
+				"User john.doe@example.com phone 070-123 45 67 partyId f47ac10b-58cc-4372-a567-0e02b2c3d479 ssn 900101-1234",
+				"User j***@example.com phone ***-*** ** ** partyId f47a... ssn ******-****"),
+			// UUID is masked first, so its twelve hexadecimal digits cannot be mistaken for a personal number.
+			Arguments.of("id 12345678-1234-1234-1234-123456789012", "id 1234..."));
+	}
+}


### PR DESCRIPTION
## Description

`LogUtils.sanitizeForLogging()` only protects against log injection (CRLF, control chars, `%`, `\`) — it does **not** mask PII, yet the word "sanitize" leads callers to assume it does (false security). This PR adds explicit PII masking plus an opt-in logback converter that masks every log line even when a developer forgets to mask manually.

- **`PiiMasker`** (`se.sundsvall.dept44.util`) — masks Swedish personal identity numbers (`******-****`), UUIDs/`partyId` (`f47a...`), e-mail addresses (`j***@example.com`) and structured Swedish phone numbers (digits → `*`, separators kept). `maskPii` applies all in a deliberate order (UUID → phone → personnummer → e-mail) so one mask can't corrupt another's match.
- **`PiiMaskingConverter`** — a logback `ClassicConverter` registered as the `%maskPii` conversion word. Activated by `dept44.logback.pii-masking.enabled` (default `false`); when off it renders identically to `%m`, so the default configuration is unchanged. (A logback `Filter`/`TurboFilter` can only accept/deny an event — it cannot rewrite message text — so a converter is the correct mechanism.)
- **`logback-spring.xml`** — registers `%maskPii` and uses it in the console + GELF short/full patterns; the enable flag is bridged into the logback context via `<springProperty>`.
- Reciprocal javadoc on `LogUtils` / `PiiMasker` so log-injection vs PII masking are not conflated.

**Scope / limitations** (documented in the module readme): masks the rendered **message** only — MDC values, caller data and stack traces emitted as separate GELF fields are not masked; free-form **street addresses are intentionally not regex-masked** (no stable shape — use field-level masking at the source); the personnummer/phone rules can over- or under-match by design. Verified with unit tests for every category plus a real-logback Joran probe (XML `<conversionRule>` + `%.-100maskPii` truncation + enabled/disabled paths).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix
- [x] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
