### PR TITLE
DRAKEN-4536 Fix concurrent token removal in OAuth2RequestInterceptor

### DIFF
--- a/dept44-starter-feign/src/main/java/se/sundsvall/dept44/configuration/feign/interceptor/OAuth2RequestInterceptor.java
+++ b/dept44-starter-feign/src/main/java/se/sundsvall/dept44/configuration/feign/interceptor/OAuth2RequestInterceptor.java
@@ -82,9 +82,32 @@ public class OAuth2RequestInterceptor implements RequestInterceptor {
 		requestTemplate.header(AUTHORIZATION, String.format("Bearer %s", accessToken.getTokenValue()));
 	}
 
-	public void removeToken() {
+	/**
+	 * Evicts the cached token, but only if it is still the exact token that caused the failing request.
+	 * <p>
+	 * When several threads share this interceptor (e.g. via {@code FeignMultiCustomizer}) and a token is rejected by
+	 * WSO2, every in-flight request carrying that token triggers a retry and calls this method. An unconditional
+	 * eviction would make each queued thread remove whatever token is currently cached - including a fresh, valid token
+	 * that another thread just fetched - causing a token-refresh storm and requests failing after their single retry.
+	 * By comparing the cached token against the one that actually failed, only the first thread evicts it; the rest
+	 * become no-ops and their retry reuses the freshly fetched token.
+	 *
+	 * @param failedAuthorizationHeader the {@code Authorization} header value (e.g. {@code "Bearer <token>"}) of the
+	 *                                  request that failed
+	 */
+	public void removeToken(final String failedAuthorizationHeader) {
 		synchronized (this) {
-			oAuth2AuthorizedClientService.removeAuthorizedClient(clientRegistration.getRegistrationId(), ANONYMOUS_AUTHENTICATION.getName());
+			final var registrationId = clientRegistration.getRegistrationId();
+			final OAuth2AuthorizedClient currentClient = oAuth2AuthorizedClientService.loadAuthorizedClient(registrationId, ANONYMOUS_AUTHENTICATION.getName());
+			if (currentClient == null) {
+				// Already evicted (and possibly refreshed) by another thread - nothing to do.
+				return;
+			}
+
+			final var currentAuthorizationHeader = String.format("Bearer %s", currentClient.getAccessToken().getTokenValue());
+			if (currentAuthorizationHeader.equals(failedAuthorizationHeader)) {
+				oAuth2AuthorizedClientService.removeAuthorizedClient(registrationId, ANONYMOUS_AUTHENTICATION.getName());
+			}
 		}
 	}
 }

--- a/dept44-starter-feign/src/main/java/se/sundsvall/dept44/configuration/feign/retryer/Action.java
+++ b/dept44-starter-feign/src/main/java/se/sundsvall/dept44/configuration/feign/retryer/Action.java
@@ -2,5 +2,13 @@ package se.sundsvall.dept44.configuration.feign.retryer;
 
 @FunctionalInterface
 public interface Action {
-	void execute();
+
+	/**
+	 * Executes the retry action for a failed request.
+	 *
+	 * @param failedAuthorizationHeader the value of the {@code Authorization} header carried by the request that failed
+	 *                                  (may be {@code null} if the request had no such header), allowing the action to
+	 *                                  act only on the exact token that failed.
+	 */
+	void execute(String failedAuthorizationHeader);
 }

--- a/dept44-starter-feign/src/main/java/se/sundsvall/dept44/configuration/feign/retryer/ActionRetryer.java
+++ b/dept44-starter-feign/src/main/java/se/sundsvall/dept44/configuration/feign/retryer/ActionRetryer.java
@@ -1,7 +1,11 @@
 package se.sundsvall.dept44.configuration.feign.retryer;
 
+import feign.Request;
 import feign.RetryableException;
 import feign.Retryer;
+import java.util.Collection;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 public class ActionRetryer implements Retryer {
 
@@ -20,8 +24,18 @@ public class ActionRetryer implements Retryer {
 		if (attempt > maxAttempts) {
 			throw e;
 		}
-		action.execute();
+		// Pass the Authorization header of the failed request so the action only acts on the exact token that failed.
+		// This avoids evicting a token that a concurrent thread has already refreshed in the meantime.
+		action.execute(extractAuthorizationHeader(e.request()));
 		attempt++;
+	}
+
+	private static String extractAuthorizationHeader(final Request request) {
+		if (request == null || request.headers() == null) {
+			return null;
+		}
+		final Collection<String> values = request.headers().get(AUTHORIZATION);
+		return (values == null || values.isEmpty()) ? null : values.iterator().next();
 	}
 
 	@Override

--- a/dept44-starter-feign/src/test/java/se/sundsvall/dept44/configuration/feign/interceptor/OAuth2RequestInterceptorTest.java
+++ b/dept44-starter-feign/src/test/java/se/sundsvall/dept44/configuration/feign/interceptor/OAuth2RequestInterceptorTest.java
@@ -50,6 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -208,10 +209,13 @@ class OAuth2RequestInterceptorTest {
 	}
 
 	@Test
-	void testRemoveToken() {
+	void testRemoveTokenWhenFailedTokenMatchesCachedToken() {
 		when(clientRegistrationMock.getRegistrationId()).thenReturn("registrationId");
 		when(clientRegistrationBuilderMock.scope(ArgumentMatchers.<HashSet<String>>any())).thenReturn(clientRegistrationBuilderMock);
 		when(clientRegistrationBuilderMock.build()).thenReturn(clientRegistrationMock);
+		when(oAuth2AuthorizedClientServiceMock.<OAuth2AuthorizedClient>loadAuthorizedClient("registrationId", "anonymousUser")).thenReturn(authorizedClientMock);
+		when(authorizedClientMock.getAccessToken()).thenReturn(accessTokenMock);
+		when(accessTokenMock.getTokenValue()).thenReturn("tokenValue");
 
 		try (MockedStatic<ClientRegistration> regMock = Mockito.mockStatic(ClientRegistration.class)) {
 			regMock.when(() -> ClientRegistration.withClientRegistration(any())).thenReturn(clientRegistrationBuilderMock);
@@ -220,11 +224,55 @@ class OAuth2RequestInterceptorTest {
 			ReflectionTestUtils.setField(interceptor, "oAuth2AuthorizedClientService", oAuth2AuthorizedClientServiceMock);
 			clearInvocations(clientRegistrationMock);
 
-			interceptor.removeToken();
+			interceptor.removeToken("Bearer tokenValue");
 		}
 
-		verify(clientRegistrationMock).getRegistrationId();
 		verify(oAuth2AuthorizedClientServiceMock).removeAuthorizedClient("registrationId", "anonymousUser");
+	}
+
+	@Test
+	void testRemoveTokenWhenFailedTokenDiffersFromCachedToken() {
+		// Simulates another thread having already refreshed the token: the cached token is no longer the one that
+		// failed, so it must NOT be evicted.
+		when(clientRegistrationMock.getRegistrationId()).thenReturn("registrationId");
+		when(clientRegistrationBuilderMock.scope(ArgumentMatchers.<HashSet<String>>any())).thenReturn(clientRegistrationBuilderMock);
+		when(clientRegistrationBuilderMock.build()).thenReturn(clientRegistrationMock);
+		when(oAuth2AuthorizedClientServiceMock.<OAuth2AuthorizedClient>loadAuthorizedClient("registrationId", "anonymousUser")).thenReturn(authorizedClientMock);
+		when(authorizedClientMock.getAccessToken()).thenReturn(accessTokenMock);
+		when(accessTokenMock.getTokenValue()).thenReturn("freshTokenValue");
+
+		try (MockedStatic<ClientRegistration> regMock = Mockito.mockStatic(ClientRegistration.class)) {
+			regMock.when(() -> ClientRegistration.withClientRegistration(any())).thenReturn(clientRegistrationBuilderMock);
+
+			OAuth2RequestInterceptor interceptor = new OAuth2RequestInterceptor(clientRegistrationMock, DEFAULT_SCOPESET);
+			ReflectionTestUtils.setField(interceptor, "oAuth2AuthorizedClientService", oAuth2AuthorizedClientServiceMock);
+			clearInvocations(clientRegistrationMock);
+
+			interceptor.removeToken("Bearer staleTokenValue");
+		}
+
+		verify(oAuth2AuthorizedClientServiceMock, never()).removeAuthorizedClient(any(), any());
+	}
+
+	@Test
+	void testRemoveTokenWhenNoCachedToken() {
+		// Simulates another thread having already evicted the token: nothing to remove.
+		when(clientRegistrationMock.getRegistrationId()).thenReturn("registrationId");
+		when(clientRegistrationBuilderMock.scope(ArgumentMatchers.<HashSet<String>>any())).thenReturn(clientRegistrationBuilderMock);
+		when(clientRegistrationBuilderMock.build()).thenReturn(clientRegistrationMock);
+		when(oAuth2AuthorizedClientServiceMock.<OAuth2AuthorizedClient>loadAuthorizedClient("registrationId", "anonymousUser")).thenReturn(null);
+
+		try (MockedStatic<ClientRegistration> regMock = Mockito.mockStatic(ClientRegistration.class)) {
+			regMock.when(() -> ClientRegistration.withClientRegistration(any())).thenReturn(clientRegistrationBuilderMock);
+
+			OAuth2RequestInterceptor interceptor = new OAuth2RequestInterceptor(clientRegistrationMock, DEFAULT_SCOPESET);
+			ReflectionTestUtils.setField(interceptor, "oAuth2AuthorizedClientService", oAuth2AuthorizedClientServiceMock);
+			clearInvocations(clientRegistrationMock);
+
+			interceptor.removeToken("Bearer anyToken");
+		}
+
+		verify(oAuth2AuthorizedClientServiceMock, never()).removeAuthorizedClient(any(), any());
 	}
 
 	@Test

--- a/dept44-starter-feign/src/test/java/se/sundsvall/dept44/configuration/feign/retryer/ActionRetryerTest.java
+++ b/dept44-starter-feign/src/test/java/se/sundsvall/dept44/configuration/feign/retryer/ActionRetryerTest.java
@@ -2,12 +2,16 @@ package se.sundsvall.dept44.configuration.feign.retryer;
 
 import feign.Request;
 import feign.RetryableException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -15,17 +19,33 @@ class ActionRetryerTest {
 
 	private final Action actionMock = Mockito.mock(Action.class);
 
+	private static RetryableException retryableException(final Map<String, Collection<String>> headers) {
+		final var request = Request.create(Request.HttpMethod.GET, "http://localhost", headers, Request.Body.empty(), null);
+		return new RetryableException(200, "message", Request.HttpMethod.GET, (Long) null, request);
+	}
+
 	@Test
 	void continueOrPropagate() {
 		final var actionRetryer = new ActionRetryer(actionMock, 2);
-		final var retryableException = new RetryableException(200, "message", Request.HttpMethod.GET, (Long) null, Mockito.mock(Request.class));
+		final var retryableException = retryableException(Map.of("Authorization", List.of("Bearer abc")));
 
 		assertDoesNotThrow(() -> actionRetryer.continueOrPropagate(retryableException));
 		assertDoesNotThrow(() -> actionRetryer.continueOrPropagate(retryableException));
 		final var exception = assertThrows(RetryableException.class, () -> actionRetryer.continueOrPropagate(retryableException));
 
 		assertThat(exception).isSameAs(retryableException);
-		verify(actionMock, times(2)).execute();
+		// The action must receive the exact Authorization header carried by the failed request.
+		verify(actionMock, times(2)).execute("Bearer abc");
+	}
+
+	@Test
+	void continueOrPropagatePassesNullWhenNoAuthorizationHeader() {
+		final var actionRetryer = new ActionRetryer(actionMock, 1);
+		final var retryableException = retryableException(Map.of());
+
+		assertDoesNotThrow(() -> actionRetryer.continueOrPropagate(retryableException));
+
+		verify(actionMock).execute(isNull());
 	}
 
 	@Test


### PR DESCRIPTION
When multiple threads share the interceptor (via FeignMultiCustomizer) and a WSO2 token is rejected, every in-flight request carrying that token triggers a retry and calls removeToken. The previous unconditional eviction made each queued thread remove whatever token was cached - including a fresh token another thread had just fetched - causing a token-refresh storm and requests failing after their single retry.

removeToken now takes the Authorization header of the failed request and only evicts the cached token if it still matches, so only the first thread refreshes and the rest reuse the freshly fetched token. The failed header is extracted from the RetryableException's request in ActionRetryer and passed through the Action interface; FeignMultiCustomizer and client configs are unchanged.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
