### PR TITLE
HYDRAN-2680: Mask 12-digit personnummer in PiiMasker + PII-logging policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ the [plugin documentation here](https://github.com/Sundsvallskommun/dept44/dept4
 **Note for `dept44`:** Because `dept44-formatting-plugin` is a module of the parent in this project, you need to run the
 commands manually for the plugin to take effect on the parent pom.
 
+## Logging & PII
+
+Personal data (`partyId`, personal/organisation numbers, names, e-mail, phone numbers) must never be
+logged in cleartext. Mask it with `se.sundsvall.dept44.util.PiiMasker` before logging. Note that
+`LogUtils.sanitizeForLogging` guards against *log injection* only — it does **not** hide PII.
+
+See the **[PII logging policy](docs/pii-logging-policy.md)** for the full guidance, the available
+masking methods, and the opt-in framework-level masker in `dept44-starter-logback-logserver`.
+
 ## Status
 
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=Sundsvallskommun_dept44&metric=alert_status)](https://sonarcloud.io/summary/overall?id=Sundsvallskommun_dept44)

--- a/dept44-starter-logback-logserver/readme.md
+++ b/dept44-starter-logback-logserver/readme.md
@@ -65,7 +65,7 @@ masked:
 
 |           Category            |             Example input              |   Masked output    |
 |-------------------------------|----------------------------------------|--------------------|
-| Swedish personal identity no. | `900101-1234`                          | `******-****`      |
+| Swedish personal identity no. | `900101-1234` / `199001011234`         | `******-****`      |
 | UUID (`partyId`)              | `f47ac10b-58cc-4372-a567-0e02b2c3d479` | `f47a...`          |
 | E-mail address                | `john.doe@example.com`                 | `j***@example.com` |
 | Swedish phone number          | `070-123 45 67`                        | `***-*** ** **`    |
@@ -83,8 +83,9 @@ identically to `%m`, so there is no behavioural change in the default configurat
 - **Street addresses are not masked.** Free-form addresses have no stable shape a regex can match without masking large
   amounts of ordinary log text; mask them field-by-field at the source instead (or via Logbook JSONPath/XPath body
   masking for HTTP payloads).
-- The personal-identity-number rule keys on the digit shape `\b\d{6}[-+]?\d{4}\b` and cannot distinguish a real
-  personnummer from any other free-standing ten-digit number, so some non-PII numbers may be masked.
+- The personal-identity-number rule keys on the digit shape `\b\d{6}(?:\d{2})?[-+]?\d{4}\b` (ten-digit `NNNNNN-NNNN`
+  and twelve-digit `NNNNNNNN-NNNN` forms) and cannot distinguish a real personnummer from any other free-standing ten-
+  or twelve-digit number, so some non-PII numbers may be masked.
 - Phone-number masking only catches structured Swedish numbers (a `+46`/`0046` prefix or an internal separator); a bare
   digit run like `0701234567` is treated as a personal identity number.
 - A service that provides its own `logback-spring.xml` (see [Override Configuration](#override-configuration)) must

--- a/dept44-starter/src/main/java/se/sundsvall/dept44/util/PiiMasker.java
+++ b/dept44-starter/src/main/java/se/sundsvall/dept44/util/PiiMasker.java
@@ -24,10 +24,11 @@ import java.util.regex.Pattern;
  * controlled and contains PII.
  *
  * <p>
- * <strong>Limitation:</strong> the personal-identity-number matcher keys on the digit shape {@code NNNNNN[-+]?NNNN} and
- * cannot tell a real personnummer apart from any other free-standing ten-digit number (an order number, an epoch-
- * millisecond timestamp, a correlation id). Such numbers may be masked even though they are not PII. Eliminating this
- * would require a date/checksum validation that is intentionally out of scope here.
+ * <strong>Limitation:</strong> the personal-identity-number matcher keys on the digit shape of a ten-digit
+ * ({@code NNNNNN[-+]?NNNN}) or twelve-digit ({@code NNNNNNNN[-+]?NNNN}) number and cannot distinguish a real
+ * personnummer from any other free-standing ten- or twelve-digit number (an order number, an epoch-millisecond
+ * timestamp, a correlation id). Such numbers may be masked even though they are not PII. Eliminating this would require
+ * a date/checksum validation that is intentionally out of scope here.
  *
  * <p>
  * <strong>Not handled:</strong> free-form street addresses are deliberately not masked - they have no stable shape a
@@ -41,10 +42,11 @@ import java.util.regex.Pattern;
 public final class PiiMasker {
 
 	/**
-	 * Swedish personal identity number on the {@code NNNNNN[-+]?NNNN} form. The {@code \b} word boundaries keep a
-	 * ten-digit run that is part of a longer number (or token) from matching.
+	 * Swedish personal identity number on the ten-digit {@code NNNNNN[-+]?NNNN} or twelve-digit
+	 * {@code NNNNNNNN[-+]?NNNN} form (the optional {@code \d{2}} is the two-digit century prefix). The {@code \b} word
+	 * boundaries keep a run that is part of a longer number (or token) from matching.
 	 */
-	private static final Pattern PERSONAL_NUMBER_PATTERN = Pattern.compile("\\b\\d{6}[-+]?\\d{4}\\b");
+	private static final Pattern PERSONAL_NUMBER_PATTERN = Pattern.compile("\\b\\d{6}(?:\\d{2})?[-+]?\\d{4}\\b");
 
 	private static final String PERSONAL_NUMBER_MASK = "******-****";
 
@@ -91,12 +93,12 @@ public final class PiiMasker {
 	}
 
 	/**
-	 * Masks Swedish personal identity numbers on the {@code NNNNNN[-+]?NNNN} form, replacing each with
-	 * {@code ******-****}.
+	 * Masks Swedish personal identity numbers on the ten-digit {@code NNNNNN[-+]?NNNN} or twelve-digit
+	 * {@code NNNNNNNN[-+]?NNNN} form, replacing each with {@code ******-****}.
 	 *
 	 * <p>
-	 * Note the limitation described on the {@linkplain PiiMasker class}: any free-standing ten-digit number matches this
-	 * shape and will be masked, whether or not it is an actual personnummer.
+	 * Note the limitation described on the {@linkplain PiiMasker class}: any free-standing ten- or twelve-digit number
+	 * matches this shape and will be masked, whether or not it is an actual personnummer.
 	 *
 	 * @param  input the string to mask
 	 * @return       a copy with personal identity numbers masked, or {@code null} if the input was {@code null}

--- a/dept44-starter/src/test/java/se/sundsvall/dept44/util/PiiMaskerTest.java
+++ b/dept44-starter/src/test/java/se/sundsvall/dept44/util/PiiMaskerTest.java
@@ -23,10 +23,19 @@ class PiiMaskerTest {
 			Arguments.of("9001011234", "******-****"),
 			Arguments.of("900101+1234", "******-****"),
 			Arguments.of("Patient 900101-1234 admitted", "Patient ******-**** admitted"),
+			// Twelve-digit (full-century) personnummer / legalId - the form the Party service returns.
+			Arguments.of("199001011234", "******-****"),
+			Arguments.of("19900101-1234", "******-****"),
+			Arguments.of("19900101+1234", "******-****"),
+			Arguments.of("legalId 199001011234 fetched", "legalId ******-**** fetched"),
+			// A 13-digit run (e.g. an epoch-millisecond timestamp) is not a personnummer; the \b boundaries keep it from
+			// matching.
+			Arguments.of("At 1700000000000 the job ran", "At 1700000000000 the job ran"),
 			// A 14-digit run is not a personnummer; the \b boundaries keep it from matching.
 			Arguments.of("Order 12345678901234 shipped", "Order 12345678901234 shipped"),
 			Arguments.of("no digits here", "no digits here"),
-			Arguments.of("900101-1234 and 850615-4321", "******-**** and ******-****"));
+			Arguments.of("900101-1234 and 850615-4321", "******-**** and ******-****"),
+			Arguments.of("199001011234 and 850615-4321", "******-**** and ******-****"));
 	}
 
 	@ParameterizedTest
@@ -99,6 +108,8 @@ class PiiMaskerTest {
 				"User john.doe@example.com phone 070-123 45 67 partyId f47ac10b-58cc-4372-a567-0e02b2c3d479 ssn 900101-1234",
 				"User j***@example.com phone ***-*** ** ** partyId f47a... ssn ******-****"),
 			// UUID is masked first, so its twelve hexadecimal digits cannot be mistaken for a personal number.
-			Arguments.of("id 12345678-1234-1234-1234-123456789012", "id 1234..."));
+			Arguments.of("id 12345678-1234-1234-1234-123456789012", "id 1234..."),
+			// Twelve-digit legalId is masked by the personal-number rule.
+			Arguments.of("legalId 199001011234 partyId f47ac10b-58cc-4372-a567-0e02b2c3d479", "legalId ******-**** partyId f47a..."));
 	}
 }

--- a/docs/pii-logging-policy.md
+++ b/docs/pii-logging-policy.md
@@ -1,0 +1,105 @@
+# PII-loggning – policy
+
+> **Kärnregel:** Inga `partyId`, `personalNumber`/`legalId`, namn, e-post eller telefonnummer i
+> klartext i loggar. Maska alltid med PII-maskeraren (`se.sundsvall.dept44.util.PiiMasker`) innan
+> värdet loggas.
+>
+> **`LogUtils.sanitizeForLogging` räcker INTE.** Den skyddar bara mot *log injection* (CRLF och
+> kontrolltecken som låter en angripare förfalska loggrader) – den döljer inte persondata. De två
+> är kompletterande, inte utbytbara.
+
+## Varför
+
+`partyId` är en direkt identifierare mot Party-tjänsten och kan slås upp till personnummer.
+Personnummer, samordningsnummer, namn, e-post och telefonnummer är personuppgifter enligt GDPR.
+Loggar hamnar i centraliserad logghantering (ELK/GELF), lagras över tid och är läsbara för fler än
+de som hanterar själva ärendet. Persondata i klartext i loggar är därför en incident som ska
+undvikas, inte en bekvämlighet.
+
+## Vad räknas som PII i det här sammanhanget
+
+| Kategori | Exempel | Maska? |
+|---|---|---|
+| `partyId` (UUID) | `f47ac10b-58cc-4372-a567-0e02b2c3d479` | **Ja** |
+| Personnummer / samordningsnummer / `legalId` | `900101-1234` | **Ja** |
+| E-postadress | `john.doe@example.com` | **Ja** |
+| Telefonnummer | `070-123 45 67` | **Ja** |
+| Namn, adress | `Anna Andersson`, `Storgatan 1` | **Ja** – maska vid källan (regex fångar inte fri text) |
+| Organisationsnummer | `5560000000` | Bedöm i sammanhanget – maska vid tveksamhet |
+
+## Så här gör du
+
+Använd `PiiMasker` från `dept44-starter`. En generell ingång maskar alla kategorier i ett svep:
+
+```java
+import se.sundsvall.dept44.util.PiiMasker;
+
+LOG.info("Inga kontaktinställningar hittades för {} med filter {}",
+    PiiMasker.maskPii(partyId), filters);
+// → "... för f47a... med filter {...}"
+```
+
+För ett värde vars typ är känd kan du använda en riktad metod – tydligare och billigare:
+
+| Metod | Använd för |
+|---|---|
+| `PiiMasker.maskPii(s)` | Generellt – godtycklig sträng som kan innehålla flera kategorier |
+| `PiiMasker.maskUuid(s)` | Ett `partyId`/UUID |
+| `PiiMasker.maskPersonalNumber(s)` | Ett personnummer / `legalId` |
+| `PiiMasker.maskEmail(s)` | En e-postadress |
+| `PiiMasker.maskPhoneNumber(s)` | Ett telefonnummer |
+
+Alla metoder är null-säkra (`null` in → `null` ut).
+
+`maskPersonalNumber` (och `maskPii`) maskar både **10-siffriga** (`YYMMDD-NNNN`, `YYMMDDNNNN`) och
+**12-siffriga** (`YYYYMMDDNNNN`, `YYYYMMDD-NNNN`) personnummer/`legalId` samt 10-siffriga
+organisationsnummer. Kräver dept44 **8.0.9+** (12-siffrigt stöd tillkom där; 8.0.8 maskar endast
+10-siffriga former).
+
+### Är värdet både angriparstyrt OCH PII?
+
+Kombinera – de skyddar mot olika saker:
+
+```java
+LOG.info("Tog emot {}", LogUtils.sanitizeForLogging(PiiMasker.maskPii(userInput)));
+```
+
+### Bästa vägen: logga inte identifieraren alls
+
+Ofta behövs inte identifieraren i loggen. Logga en räknare, ett internt id eller en status i
+stället för `partyId`/personnummer:
+
+```java
+LOG.info("Hittade {} poster utan partyId", records.size());   // ok – ingen PII
+```
+
+## Skyddsnät på ramverksnivå (ersätter inte maskning i koden)
+
+`dept44-starter-logback-logserver` har en **opt-in** maskerare som maskar PII i *varje* loggrad
+(konsol och GELF), oavsett om koden kom ihåg att maska:
+
+```properties
+dept44.logback.pii-masking.enabled=true
+```
+
+Detta är ett skyddsnät (defense-in-depth), **inte** en ersättning för att maska vid källan:
+
+- Det maskar bara det renderade **meddelandet**. MDC-värden, caller data och stack traces som
+  GELF-encodern skickar som separata fält maskas **inte**.
+- Fri text (namn, adress) fångas inte av regex.
+- En tjänst med egen `logback-spring.xml` måste själv replikera `<conversionRule>` och
+  `%maskPii`-mönstret.
+
+Se `dept44-starter-logback-logserver/readme.md` för detaljer och begränsningar.
+
+## Checklista vid PR
+
+- [ ] Loggar har granskats för PII – inga `partyId`, personnummer/`legalId`, namn, e-post eller
+      telefonnummer i klartext.
+- [ ] Där PII loggas är värdet maskat med `PiiMasker` (inte enbart `sanitizeForLogging`).
+
+## Referenser
+
+- `se.sundsvall.dept44.util.PiiMasker` (`dept44-starter`)
+- `se.sundsvall.dept44.util.LogUtils#sanitizeForLogging` – *endast* log injection
+- `dept44-starter-logback-logserver/readme.md` – ramverkets opt-in-maskerare


### PR DESCRIPTION
## What

Two related PII-in-logs changes:

### 1. `PiiMasker` masks 12-digit personnummer/`legalId`

The personal-number pattern only matched the **10-digit** form, so a **12-digit** `legalId`/personnummer (`YYYYMMDDNNNN`) — the form the Party service returns — and the 8+4 hyphenated form (`YYYYMMDD-NNNN`) passed through **unmasked**.

`\b\d{6}[-+]?\d{4}\b` → `\b\d{6}(?:\d{2})?[-+]?\d{4}\b` (the optional `(?:\d{2})?` is the century prefix).

| Input | before | after |
|---|---|---|
| `900101-1234`, `9001011234` | masked | masked |
| `199001011234` (12-digit) | **not masked** | `******-****` |
| `19900101-1234` (8+4) | **not masked** | `******-****` |
| `1700000000000` (13), `12345678901234` (14) | unchanged | unchanged |

A 13/14-digit run still fails the `\b` boundary, so genuinely long numbers (order ids, epoch-millis) stay unmasked as before.

### 2. PII-logging policy (`docs/pii-logging-policy.md`)

New team-facing policy: never log `partyId`/`personalNumber`/`legalId`/name/email in cleartext — mask with `PiiMasker`; `LogUtils.sanitizeForLogging` guards **log injection only, not PII**. Linked from `README.md`.

## Tests

`PiiMaskerTest` gains 12-digit cases (bare / hyphen / `+` / in-sentence / mixed with a 10-digit) plus a 13-digit negative, and a 12-digit case in the `maskPii` composite. **`Tests run: 49, Failures: 0`.**

## Notes

- Lands in **8.0.9**; services need to bump to 8.0.9 to get 12-digit masking (`maskUuid` for `partyId` is unaffected and already works on 8.0.8).
- The `dept44-starter-logback-logserver` readme limitation note is updated to match.