### PR TITLE
hydran-xyz-sonar-issues

### DIFF
--- a/dept44-build-tools/src/main/java/se/sundsvall/dept44/maven/mojo/CheckTruststoreValidityMojo.java
+++ b/dept44-build-tools/src/main/java/se/sundsvall/dept44/maven/mojo/CheckTruststoreValidityMojo.java
@@ -47,7 +47,7 @@ public class CheckTruststoreValidityMojo extends AbstractDept44CheckMojo {
 		try {
 			var truststoreDir = new File(getProject().getBasedir(), "src/main/resources/" + truststorePath);
 
-			var today = LocalDate.now();
+			var today = LocalDate.now(ZoneId.systemDefault());
 			var expiry = today.plusMonths(monthsUntilExpiration);
 
 			var certificateFiles = truststoreDir.listFiles(File::isFile);


### PR DESCRIPTION
Fixes the single open **java.time** SonarCloud issue in this repo (`java:S8688`).

> Explicitly specify the time zone by passing a ZoneId or a Clock to the `.now()` method.

`CheckTruststoreValidityMojo` derived `today` from a no-arg `LocalDate.now()`. It now passes `ZoneId.systemDefault()` explicitly — which is the zone the same method already uses a few lines below when converting each certificate's `notAfter` to a `LocalDate`, so this makes the two consistent. `ZoneId` was already imported. Behaviour unchanged.

### Verification
`mvn clean verify -pl dept44-build-tools -am` — green, 15 tests.