### PR TITLE
HYDRAN-2653 Bump Spring Cloud to 2025.1.3 and drop Spring Cloud Contract

### DIFF
--- a/dept44-starter-test/pom.xml
+++ b/dept44-starter-test/pom.xml
@@ -39,13 +39,22 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-resttestclient</artifactId>
 		</dependency>
+		<!-- TestRestTemplate needs the RestClient/HttpClient support classes at runtime -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-restclient</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-webtestclient</artifactId>
 		</dependency>
+		<!-- Provides the shaded handlebars classes used by AbstractAppTest. Scope is explicit, since
+				spring-cloud-kubernetes-dependencies manages this artifact as test-scoped. -->
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-contract-wiremock</artifactId>
+			<groupId>org.wiremock</groupId>
+			<artifactId>wiremock-standalone</artifactId>
+			<version>${wiremock.version}</version>
+			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.wiremock.integrations</groupId>

--- a/dept44-starter/src/main/resources/config/application.properties
+++ b/dept44-starter/src/main/resources/config/application.properties
@@ -15,10 +15,6 @@ springdoc.swagger-ui.tags-sorter=alpha
 # Logging
 logging.file.path=log
 logging.level.se.sundsvall.dept44.payload=TRACE
-# Suppress WARN with stacktrace from spring-cloud-context 5.0.2 when resetting constructor-bound
-# @ConfigurationProperties (e.g. the spring-cloud-kubernetes properties records). Fixed upstream in
-# spring-cloud-commons commit 679cf202 - remove this when Spring Cloud >= 2025.1.3 is used.
-logging.level.org.springframework.cloud.context.properties.ConfigurationPropertiesRebinder=ERROR
 logbook.default.logger.name=se.sundsvall.dept44.payload
 logbook.default.excluded.paths=/,**/webjars/**,**${springdoc.api-docs.path}**,**/swagger-resources,**/swagger-resources/**,**/error,**/csrf,**/swagger-ui.html,**/swagger-ui/**,**/favicon.ico,**/actuator,**/actuator/**,**/h2-console/**
 # Jackson

--- a/dept44-starter/src/test/java/se/sundsvall/dept44/logbook/filter/BodyFilterProviderTest.java
+++ b/dept44-starter/src/test/java/se/sundsvall/dept44/logbook/filter/BodyFilterProviderTest.java
@@ -25,10 +25,10 @@ import se.sundsvall.dept44.test.annotation.resource.Load;
 import se.sundsvall.dept44.test.extension.ResourceLoaderExtension;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
-import static org.apache.http.entity.ContentType.APPLICATION_JSON;
-import static org.apache.http.entity.ContentType.APPLICATION_XHTML_XML;
-import static org.apache.http.entity.ContentType.APPLICATION_XML;
-import static org.apache.http.entity.ContentType.TEXT_XML;
+import static org.apache.hc.core5.http.ContentType.APPLICATION_JSON;
+import static org.apache.hc.core5.http.ContentType.APPLICATION_XHTML_XML;
+import static org.apache.hc.core5.http.ContentType.APPLICATION_XML;
+import static org.apache.hc.core5.http.ContentType.TEXT_XML;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;

--- a/docs/pii-logging-policy.md
+++ b/docs/pii-logging-policy.md
@@ -18,14 +18,14 @@ undvikas, inte en bekvämlighet.
 
 ## Vad räknas som PII i det här sammanhanget
 
-| Kategori | Exempel | Maska? |
-|---|---|---|
-| `partyId` (UUID) | `f47ac10b-58cc-4372-a567-0e02b2c3d479` | **Ja** |
-| Personnummer / samordningsnummer / `legalId` | `900101-1234` | **Ja** |
-| E-postadress | `john.doe@example.com` | **Ja** |
-| Telefonnummer | `070-123 45 67` | **Ja** |
-| Namn, adress | `Anna Andersson`, `Storgatan 1` | **Ja** – maska vid källan (regex fångar inte fri text) |
-| Organisationsnummer | `5560000000` | Bedöm i sammanhanget – maska vid tveksamhet |
+|                   Kategori                   |                Exempel                 |                         Maska?                         |
+|----------------------------------------------|----------------------------------------|--------------------------------------------------------|
+| `partyId` (UUID)                             | `f47ac10b-58cc-4372-a567-0e02b2c3d479` | **Ja**                                                 |
+| Personnummer / samordningsnummer / `legalId` | `900101-1234`                          | **Ja**                                                 |
+| E-postadress                                 | `john.doe@example.com`                 | **Ja**                                                 |
+| Telefonnummer                                | `070-123 45 67`                        | **Ja**                                                 |
+| Namn, adress                                 | `Anna Andersson`, `Storgatan 1`        | **Ja** – maska vid källan (regex fångar inte fri text) |
+| Organisationsnummer                          | `5560000000`                           | Bedöm i sammanhanget – maska vid tveksamhet            |
 
 ## Så här gör du
 
@@ -41,13 +41,13 @@ LOG.info("Inga kontaktinställningar hittades för {} med filter {}",
 
 För ett värde vars typ är känd kan du använda en riktad metod – tydligare och billigare:
 
-| Metod | Använd för |
-|---|---|
-| `PiiMasker.maskPii(s)` | Generellt – godtycklig sträng som kan innehålla flera kategorier |
-| `PiiMasker.maskUuid(s)` | Ett `partyId`/UUID |
-| `PiiMasker.maskPersonalNumber(s)` | Ett personnummer / `legalId` |
-| `PiiMasker.maskEmail(s)` | En e-postadress |
-| `PiiMasker.maskPhoneNumber(s)` | Ett telefonnummer |
+|               Metod               |                            Använd för                            |
+|-----------------------------------|------------------------------------------------------------------|
+| `PiiMasker.maskPii(s)`            | Generellt – godtycklig sträng som kan innehålla flera kategorier |
+| `PiiMasker.maskUuid(s)`           | Ett `partyId`/UUID                                               |
+| `PiiMasker.maskPersonalNumber(s)` | Ett personnummer / `legalId`                                     |
+| `PiiMasker.maskEmail(s)`          | En e-postadress                                                  |
+| `PiiMasker.maskPhoneNumber(s)`    | Ett telefonnummer                                                |
 
 Alla metoder är null-säkra (`null` in → `null` ut).
 
@@ -95,7 +95,7 @@ Se `dept44-starter-logback-logserver/readme.md` för detaljer och begränsningar
 ## Checklista vid PR
 
 - [ ] Loggar har granskats för PII – inga `partyId`, personnummer/`legalId`, namn, e-post eller
-      telefonnummer i klartext.
+  telefonnummer i klartext.
 - [ ] Där PII loggas är värdet maskat med `PiiMasker` (inte enbart `sanitizeForLogging`).
 
 ## Referenser
@@ -103,3 +103,4 @@ Se `dept44-starter-logback-logserver/readme.md` för detaljer och begränsningar
 - `se.sundsvall.dept44.util.PiiMasker` (`dept44-starter`)
 - `se.sundsvall.dept44.util.LogUtils#sanitizeForLogging` – *endast* log injection
 - `dept44-starter-logback-logserver/readme.md` – ramverkets opt-in-maskerare
+

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,9 @@
 		<commons-lang3.version>3.20.0</commons-lang3.version>
 		<logbook.version>4.1.0</logbook.version>
 		<springdoc.version>3.1.0</springdoc.version>
-		<spring-cloud.version>2025.1.2</spring-cloud.version>
+		<spring-cloud.version>2025.1.3</spring-cloud.version>
+		<!-- Must track the WireMock version that wiremock-spring-boot pulls in, since both end up on the test classpath -->
+		<wiremock.version>3.13.2</wiremock.version>
 		<resilience4j.version>2.4.0</resilience4j.version>
 		<bean-matchers.version>0.14</bean-matchers.version>
 		<google-guava.version>33.6.0-jre</google-guava.version>


### PR DESCRIPTION
Bumps Spring Cloud to 2025.1.3, removes the logging suppression that release makes
redundant, and deals with the fallout of Spring Cloud Contract leaving the release train.

## Background

**1. The suppression can go.** 2025.1.3 ships spring-cloud-commons 5.0.3, which contains
the `ConfigurationPropertiesRebinder` fix ([commit `679cf202`](https://github.com/spring-cloud/spring-cloud-commons/commit/679cf202)).
The `logging.level...ConfigurationPropertiesRebinder=ERROR` line added in HYDRAN-2652 is
no longer needed and has been removed, as planned in the comment above it.

**2. The same release train breaks the build.** 2025.1.3 also drops
`spring-cloud-contract-dependencies` from its BOM, which leaves
`spring-cloud-contract-wiremock` without a managed version:

```
'dependencies.dependency.version' for org.springframework.cloud:spring-cloud-contract-wiremock:jar is missing.
```

This is deliberate, not a packaging accident. Spring Cloud Contract has been handed over to
the independent [Stubborn.sh](https://stubborn.sh/transition-guide/) project
([announcement](https://spring.io/blog/2026/07/06/spring-cloud-contract-transition-to-stubbornsh)),
the repo now lives in `spring-attic`, and it was removed from the release train in
`spring-cloud-release` commits `9f2fd5e7` and `e46fe3dd`. 5.0.3 is the last Spring-published
version. The release notes do not mention any of this.

## Approach

Rather than pin the last version of an archived artifact, the dependency is removed. dept44
uses **no** classes from `org.springframework.cloud.contract.*` — everything goes through
`com.github.tomakehurst.wiremock.*` and `org.wiremock.spring.*`. A grep across all locally
cloned services turned up no usage anywhere in the fleet either.

It was only acting as a transitive supplier, and a costly one: it pulled **24 artifacts in
compile scope** onto every downstream service's test classpath — the entire Maven resolver
stack (`maven-model-builder`, `plexus`, `sisu`), httpclient 4.x, gson. The `dept44-starter-test`
dependency list drops from 144 to 121.

What it genuinely provided is now declared explicitly:

| Dependency | Why |
|---|---|
| `org.wiremock:wiremock-standalone` | `AbstractAppTest` uses the shaded `wiremock.com.github.jknack.handlebars` classes |
| `org.springframework.boot:spring-boot-restclient` | `TestRestTemplate` needs the RestClient/HttpClient support classes at runtime |

Two traps worth flagging for reviewers:

- `wiremock-standalone` needs an **explicit `<scope>compile</scope>`**.
  `spring-cloud-kubernetes-dependencies` manages it as test-scoped, and previously lost to
  Contract's BOM on first-declaration-wins. Without the explicit scope you get
  `package wiremock.com.github.jknack.handlebars does not exist` when compiling `AbstractAppTest`.
- `BodyFilterProviderTest` was importing `org.apache.http.entity.ContentType` — httpclient
  **4.x**, which only reached the classpath through that accidental transitive path. It now
  uses the httpclient5 constants, which are on the classpath for real.

The second commit is `mvn dept44-formatting:apply` output for `docs/pii-logging-policy.md`,
which was not formatter-clean. Separated so it does not muddy the review.

## Verification

- `mvn clean verify` green across the whole reactor, including `dept44-example`'s AppTests
  (WireMock, Feign, circuit breakers, schedulers).
- No service in the fleet uses any of the 24 removed artifacts. `api-service-json-schema` was
  the one near-miss — it uses `maven-artifact`, but declares it explicitly with its own version.

Not yet built: a real downstream service against `8.0.10-SNAPSHOT`. Worth a smoke test on a
service with heavy AppTests before release.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix
- [ ] New feature
- [x] Removed feature
- [x] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
