### PR TITLE
HYDRAN-2655 Make truststore replacement of JVM default trust anchors explicit

### DIFF
--- a/dept44-starter/README.md
+++ b/dept44-starter/README.md
@@ -51,7 +51,30 @@ Default Resilience4j circuit breaker configuration for fault tolerance.
 
 ### Truststore
 
-Automatic SSL/TLS truststore loading from `truststore/*` path. Configure via `dept44.truststore.path`.
+Certificates found on the `truststore/*` classpath path (configurable via `dept44.truststore.path`) are loaded
+into an in-memory truststore together with the CA certificates bundled in this starter, and that truststore is
+installed as the JVM default via `SSLContext.setDefault(...)`.
+
+**This replaces the JVM default trust anchors rather than adding to them.** The JDK `cacerts` store is not used
+by the application once the starter has initialised. The resulting trust set is the bundled CA certificates plus
+whatever you add yourself - nothing else. This is intentional: services talk to a known set of endpoints, and a
+curated CA list is a smaller attack surface than the ~110 public roots in `cacerts`.
+
+The practical consequences:
+
+- A server certificate that any browser or `curl` accepts may still fail with
+  `PKIX path building failed / unable to find valid certification path` if its CA is not in the bundled set.
+  This is the expected outcome, not a misconfiguration.
+- Importing the CA into the JDK's `cacerts` will **not** help, for the same reason. Add the CA (or the server's
+  own certificate) in X.509 (PEM) format to `src/main/resources/truststore/` instead, or point
+  `dept44.truststore.path` at a directory that contains it.
+- Certificates that have expired are skipped with a warning and are silently not trusted, so an expired PEM in
+  `truststore/` behaves the same as a missing one.
+- The trust set applies process-wide, but only to clients that honour the JVM default `SSLContext` - which
+  includes the default Feign client. OkHttp resolves its own platform trust manager and therefore needs the
+  truststore wired in explicitly (`dept44-starter-feign` does this for its OkHttp client).
+
+The set of trust anchors actually installed is logged at `INFO` on startup.
 
 ## Key Dependencies
 

--- a/dept44-starter/src/main/java/se/sundsvall/dept44/security/Truststore.java
+++ b/dept44-starter/src/main/java/se/sundsvall/dept44/security/Truststore.java
@@ -80,6 +80,9 @@ public class Truststore {
 	private static final String MESSAGE_NO_VALID_CERTIFICATES = "Could not find any valid certificates.";
 	private static final String MESSAGE_NO_RESOURCES_FOUND = "No resources found on path: '{}'";
 	private static final String MESSAGE_USAGE_INFO = "Truststore enabled, with truststore path: '{}'. Use 'dept44.truststore.path' to change path to your trusted certificates";
+	private static final String MESSAGE_REPLACES_JVM_DEFAULT = "Installed {} certificate(s) as the JVM default trust anchors. "
+		+ "These are now the ONLY trusted CAs for this process - the JDK 'cacerts' store is NOT in use. "
+		+ "To trust an additional CA (for example an external party's server certificate), add its X.509 (PEM) certificate to '{}'.";
 
 	private static final String SSL_PROTOCOL = "TLSv1.2";
 	private static final String CERTIFICATE_TYPE = "X.509";
@@ -180,6 +183,7 @@ public class Truststore {
 		});
 
 		this.trustManagerFactory.init(keyStore);
+		LOG.info(MESSAGE_REPLACES_JVM_DEFAULT, keyStore.size(), trustStorePath);
 
 		final var customSSLContext = SSLContext.getInstance(SSL_PROTOCOL);
 		customSSLContext.init(null, this.trustManagerFactory.getTrustManagers(), new SecureRandom());


### PR DESCRIPTION
## Description

`Truststore` loads the certificates bundled in this starter plus anything on `dept44.truststore.path` into an in-memory truststore, and installs it as the JVM default via `SSLContext.setDefault(...)`. That **replaces** the JDK's `cacerts` trust anchors rather than adding to them: a dept44 service trusts the 8 bundled CAs plus whatever the service adds, not the ~110 public roots in `cacerts`.

The policy is deliberate and stays as it is — a curated CA list is a smaller attack surface for services talking to a known set of endpoints. The problem was that it was neither documented nor visible at runtime.

Reported downstream in Sundsvallskommun/api-service-oep-integrator#96 by a municipality evaluating the service against their own OpenE instance. Their certificate was valid — browser fine, `curl` fine — but the application failed with `PKIX path building failed`, and the obvious next step, importing the CA into `cacerts`, does nothing because `cacerts` is not in use. Nothing said so anywhere.

Verified with a throwaway probe against two local HTTPS servers, one with its certificate in `truststore/` and one without: the first is trusted, the second reproduces the PKIX error exactly. The existing remedy works, it just wasn't discoverable.

**Changes**

- `Truststore` logs, once the anchors are installed, how many were loaded, that `cacerts` is not in use, and where to add your own. This lands in the startup log of every dept44 service — where someone hitting the error is already looking.
- The starter README's Truststore section now documents the replacement semantics, the `cacerts` dead end, the silent skipping of expired PEMs, and that OkHttp resolves its own platform trust manager and so needs the truststore wired in explicitly.

**Verification:** `mvn -o -pl dept44-starter test` — 473 tests green, coverage gate included. No new tests: the only code change is a single log statement on an already-covered path, so there is nothing meaningfully new to assert.

```
Installed 8 certificate(s) as the JVM default trust anchors. These are now the ONLY
trusted CAs for this process - the JDK 'cacerts' store is NOT in use. To trust an
additional CA (for example an external party's server certificate), add its X.509
(PEM) certificate to 'truststore/*'.
```

**Deliberately not changed:** making the truststore extend `cacerts` instead of replacing it. That would silently widen trust across every service to make one onboarding case easier.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
