### PR TITLE
DRAKEN-4775: Revert FeignConfiguration converter workaround

### DIFF
--- a/dept44-starter-feign/src/main/java/se/sundsvall/dept44/configuration/feign/FeignConfiguration.java
+++ b/dept44-starter-feign/src/main/java/se/sundsvall/dept44/configuration/feign/FeignConfiguration.java
@@ -93,7 +93,7 @@ public class FeignConfiguration {
 				.addFirstWriter(writer);
 		}
 
-		return new PageableSpringEncoder(new SpringEncoder(formEncoder, encoderProperties, eagerlyInitialized(messageConverters)));
+		return new PageableSpringEncoder(new SpringEncoder(formEncoder, encoderProperties, messageConverters));
 	}
 
 	/**
@@ -108,27 +108,7 @@ public class FeignConfiguration {
 		return new OptionalDecoder(
 			new ResponseEntityDecoder(
 				new BinaryAwareDecoder(
-					new SpringDecoder(eagerlyInitialized(messageConverters)))));
-	}
-
-	/**
-	 * Initializes the converters held by {@link FeignHttpMessageConverters} while the client context is still being built,
-	 * i.e. while it is single-threaded.
-	 * <p>
-	 * {@code FeignHttpMessageConverters.initConvertersIfRequired()} assigns its field an empty list before it fills the
-	 * list, and neither synchronizes nor declares the field volatile. A thread reading the field within that window sees a
-	 * non-null but empty list, skips the initialization and is handed no converters at all, which makes
-	 * {@link SpringDecoder} and {@link SpringEncoder} fail with {@code 'messageConverters' must not be empty}. Both hold
-	 * the provider rather than the converters, so the initialization is otherwise triggered by the first request, where a
-	 * burst of concurrent calls against a cold client hits the window reliably.
-	 * <p>
-	 * Reported upstream as spring-cloud-openfeign
-	 * <a href="https://github.com/spring-cloud/spring-cloud-openfeign/issues/1307">#1307</a>, which is still open. Remove
-	 * this once a released version initializes the converters safely.
-	 */
-	private static ObjectProvider<FeignHttpMessageConverters> eagerlyInitialized(final ObjectProvider<FeignHttpMessageConverters> messageConverters) {
-		messageConverters.ifAvailable(FeignHttpMessageConverters::getConverters);
-		return messageConverters;
+					new SpringDecoder(messageConverters))));
 	}
 
 	@Bean

--- a/dept44-starter-feign/src/test/java/se/sundsvall/dept44/configuration/feign/FeignConfigurationTest.java
+++ b/dept44-starter-feign/src/test/java/se/sundsvall/dept44/configuration/feign/FeignConfigurationTest.java
@@ -7,7 +7,6 @@ import feign.okhttp.OkHttpClient;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,10 +32,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.springframework.http.MediaType.ALL;
 
 @SpringBootTest(classes = {
@@ -114,24 +109,6 @@ class FeignConfigurationTest {
 	}
 
 	@Test
-	void testFeignEncoderInitializesConvertersEagerly() {
-		final var converters = mock(FeignHttpMessageConverters.class);
-
-		configuration.feignEncoder(formWriter, encoderProperties, providerOf(converters));
-
-		verify(converters).getConverters();
-	}
-
-	@Test
-	void testFeignDecoderInitializesConvertersEagerly() {
-		final var converters = mock(FeignHttpMessageConverters.class);
-
-		configuration.feignDecoder(providerOf(converters));
-
-		verify(converters).getConverters();
-	}
-
-	@Test
 	void testQueryMapEncoder() {
 		assertThat(configuration.queryMapEncoder()).isNotNull().isInstanceOf(QueryMapEncoder.class);
 	}
@@ -171,16 +148,5 @@ class FeignConfigurationTest {
 		// Verify it supports all media types
 		final var byteArrayConverter = (ByteArrayHttpMessageConverter) converters.getFirst();
 		assertThat(byteArrayConverter.getSupportedMediaTypes()).contains(ALL);
-	}
-
-	@SuppressWarnings("unchecked")
-	private static ObjectProvider<FeignHttpMessageConverters> providerOf(final FeignHttpMessageConverters converters) {
-		final ObjectProvider<FeignHttpMessageConverters> provider = mock(ObjectProvider.class);
-		doAnswer(invocation -> {
-			invocation.getArgument(0, Consumer.class).accept(converters);
-			return null;
-		}).when(provider).ifAvailable(any());
-
-		return provider;
 	}
 }


### PR DESCRIPTION
spring-cloud-openfeign 5.0.3 initializes FeignHttpMessageConverters behind a double-checked lock on a volatile field and assigns the field only once the list is fully built, so the converters are no longer published empty. dept44 resolves 5.0.3 through the Spring Cloud 2025.1.3 bump, which makes the eager initialization redundant.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix
- [ ] New feature
- [x] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [ ] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added/updated tests to cover my changes (if applicable).
